### PR TITLE
Enhance admin controls for portfolio and project management

### DIFF
--- a/src/app/(index)/Portfolio.tsx
+++ b/src/app/(index)/Portfolio.tsx
@@ -1,14 +1,181 @@
+"use client";
+
 import styles from "./portfolio.module.scss";
 import Link from "next/link";
+import { useEffect, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import EditableText from "@/components/EditableText";
+import { useDragReorder } from "@/components/useDragReorder";
+import {
+  saveConfig,
+  createPortfolioCard,
+  type PortfolioCard as Card
+} from "@/app/admin/contentActions";
+import { applyConfigToCards, cardFlags, type SiteConfigData } from "@/lib/siteConfig";
 
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { library } from '@fortawesome/fontawesome-svg-core';
-import { fas } from '@fortawesome/free-solid-svg-icons';
+import {
+  faGripVertical,
+  faEye,
+  faEyeSlash,
+  faPlus
+} from "@fortawesome/free-solid-svg-icons";
+import { library } from "@fortawesome/fontawesome-svg-core";
+import { fas } from "@fortawesome/free-solid-svg-icons";
 
 library.add(fas);
 
-export default function Portfolio({ className, cards, description, isAdmin = false }) {
+function CardView({
+  card,
+  isAdmin,
+  hidden,
+  innerRef,
+  onHandlePointerDown,
+  onToggleHide,
+  floating
+}: any) {
+  // A bad icon name renders nothing (FontAwesome warns); fall back so the slot
+  // never collapses while the admin is typing a new name.
+  const iconName = card.fontAwesomeIcon || "star";
+
+  const body = (
+    <>
+      {isAdmin && (
+        <div className={styles.adminOverlay}>
+          {onHandlePointerDown && (
+            <button
+              type="button"
+              className={styles.dragHandle}
+              aria-label="Drag to reorder"
+              onPointerDown={onHandlePointerDown}
+            >
+              <FontAwesomeIcon icon={faGripVertical} />
+            </button>
+          )}
+          <button
+            type="button"
+            className={hidden ? "" : styles.flagActive}
+            aria-label={hidden ? "Show card" : "Hide card"}
+            onClick={onToggleHide}
+          >
+            <FontAwesomeIcon icon={hidden ? faEyeSlash : faEye} />
+          </button>
+        </div>
+      )}
+
+      <div className={styles.quickLinkIcon}>
+        <FontAwesomeIcon icon={["fas", iconName]} />
+      </div>
+      {isAdmin && (
+        <p className={styles.adminFieldHint}>
+          Icon:{" "}
+          <EditableText model="PortfolioCard" id={card.id} field="fontAwesomeIcon" value={card.fontAwesomeIcon} editable>
+            {card.fontAwesomeIcon}
+          </EditableText>
+        </p>
+      )}
+
+      <h3>
+        <EditableText model="PortfolioCard" id={card.id} field="title" value={card.title} editable={isAdmin}>
+          {card.title}
+        </EditableText>
+      </h3>
+      <p className={styles.description}>
+        <EditableText model="PortfolioCard" id={card.id} field="description" value={card.description} editable={isAdmin} multiline>
+          {card.description}
+        </EditableText>
+      </p>
+      <p className={styles.shortDescription}>
+        <EditableText model="PortfolioCard" id={card.id} field="shortDescription" value={card.shortDescription} editable={isAdmin} multiline>
+          {card.shortDescription}
+        </EditableText>
+      </p>
+
+      {isAdmin ? (
+        <div className={styles.adminLinkBlock}>
+          <span className={styles.linkPreview}>
+            <EditableText model="PortfolioCard" id={card.id} field="linkText" value={card.linkText} editable>
+              {card.linkText}
+            </EditableText>
+          </span>
+          <p className={styles.adminFieldHint}>
+            Links to:{" "}
+            <EditableText model="PortfolioCard" id={card.id} field="link" value={card.link} editable>
+              {card.link}
+            </EditableText>
+          </p>
+        </div>
+      ) : (
+        <Link href={card.link}>{card.linkText}</Link>
+      )}
+    </>
+  );
+
+  return (
+    <div
+      ref={innerRef}
+      className={`${styles.quickLinkCard} ${isAdmin ? styles.adminCard : ""} ${
+        hidden ? styles.hiddenCard : ""
+      } ${floating ? styles.floating : ""}`}
+    >
+      {body}
+    </div>
+  );
+}
+
+export default function Portfolio({ className, cards, description, config, isAdmin = false }: any) {
+  const router = useRouter();
+  const [cfg, setCfg] = useState<SiteConfigData>(config);
+  const [items, setItems] = useState<Card[]>(() => applyConfigToCards(cards, config, isAdmin));
+  const [creating, setCreating] = useState(false);
+  const cfgRef = useRef(cfg);
+
+  useEffect(() => { cfgRef.current = cfg; }, [cfg]);
+  // Re-derive from the server only when fresh props arrive (refresh/navigation).
+  useEffect(() => {
+    setCfg(config);
+    setItems(applyConfigToCards(cards, config, isAdmin));
+  }, [cards, config, isAdmin]);
+
+  async function persist(next: SiteConfigData) {
+    setCfg(next);
+    const result = await saveConfig(next);
+    if ("error" in result) {
+      alert(`Save failed: ${result.error}`);
+      router.refresh();
+    }
+  }
+
+  function toggleHide(id: string) {
+    const current = cardFlags(cfgRef.current, id);
+    persist({
+      ...cfgRef.current,
+      portfolioCards: { ...cfgRef.current.portfolioCards, [id]: { hidden: !current.hidden } }
+    });
+  }
+
+  async function addCard() {
+    setCreating(true);
+    const result = await createPortfolioCard();
+    setCreating(false);
+    if ("error" in result) {
+      alert(`Couldn't add card: ${result.error}`);
+    } else {
+      const nextItems = [...items, result.card];
+      setItems(nextItems);
+      persist({ ...cfgRef.current, portfolioCardOrder: nextItems.map((c) => c.id) });
+    }
+  }
+
+  const drag = useDragReorder<Card>({
+    items,
+    setItems,
+    getKey: (c) => c.id,
+    onCommit: (ids) => persist({ ...cfgRef.current, portfolioCardOrder: ids })
+  });
+
+  const draggingCard = drag.draggingKey ? items.find((c) => c.id === drag.draggingKey) : null;
+
   return (
     <div className={className}>
       <h2 className={styles.sectionHeader}>
@@ -23,35 +190,46 @@ export default function Portfolio({ className, cards, description, isAdmin = fal
       </p>
 
       <div className={styles.quickLinks}>
-        {cards.map((card) => (
-          <div key={card.id} className={styles.quickLinkCard}>
-            <div className={styles.quickLinkIcon}>
-              <FontAwesomeIcon icon={['fas', card.fontAwesomeIcon]} />
-            </div>
-            <h3>
-              <EditableText model="PortfolioCard" id={card.id} field="title" value={card.title} editable={isAdmin}>
-                {card.title}
-              </EditableText>
-            </h3>
-            <p className={styles.description}>
-              <EditableText model="PortfolioCard" id={card.id} field="description" value={card.description} editable={isAdmin} multiline>
-                {card.description}
-              </EditableText>
-            </p>
-            <p className={styles.shortDescription}>
-              <EditableText model="PortfolioCard" id={card.id} field="shortDescription" value={card.shortDescription} editable={isAdmin} multiline>
-                {card.shortDescription}
-              </EditableText>
-            </p>
+        {items.map((card, index) =>
+          card.id === drag.draggingKey ? (
+            <div
+              key={card.id}
+              className={styles.placeholder}
+              style={{ width: drag.size.w, height: drag.size.h }}
+            />
+          ) : (
+            <CardView
+              key={card.id}
+              card={card}
+              isAdmin={isAdmin}
+              hidden={isAdmin && cardFlags(cfg, card.id).hidden}
+              innerRef={drag.registerCard(card.id)}
+              onHandlePointerDown={
+                isAdmin ? (e: React.PointerEvent) => drag.startDrag(index, card.id, e) : undefined
+              }
+              onToggleHide={() => toggleHide(card.id)}
+            />
+          )
+        )}
 
-            <Link href={card.link}>
-              <EditableText model="PortfolioCard" id={card.id} field="linkText" value={card.linkText} editable={isAdmin}>
-                {card.linkText}
-              </EditableText>
-            </Link>
-          </div>
-        ))}
+        {isAdmin && (
+          <button
+            type="button"
+            className={styles.addCardButton}
+            onClick={addCard}
+            disabled={creating}
+          >
+            <FontAwesomeIcon icon={faPlus} />
+            <span>{creating ? "Adding…" : "Add card"}</span>
+          </button>
+        )}
       </div>
+
+      {draggingCard && isAdmin && (
+        <div className={styles.floatingLayer} style={drag.floatingStyle}>
+          <CardView card={draggingCard} isAdmin floating hidden={cardFlags(cfg, draggingCard.id).hidden} />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/app/(index)/Portfolio.tsx
+++ b/src/app/(index)/Portfolio.tsx
@@ -9,6 +9,8 @@ import { useDragReorder } from "@/components/useDragReorder";
 import {
   saveConfig,
   createPortfolioCard,
+  updatePortfolioCard,
+  deletePortfolioCard,
   type PortfolioCard as Card
 } from "@/app/admin/contentActions";
 import { applyConfigToCards, cardFlags, type SiteConfigData } from "@/lib/siteConfig";
@@ -16,14 +18,43 @@ import { applyConfigToCards, cardFlags, type SiteConfigData } from "@/lib/siteCo
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import {
   faGripVertical,
+  faPen,
   faEye,
   faEyeSlash,
-  faPlus
+  faPlus,
+  faTrash
 } from "@fortawesome/free-solid-svg-icons";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import { fas } from "@fortawesome/free-solid-svg-icons";
 
 library.add(fas);
+
+// Editable card fields, in the order they appear in the modal.
+type CardForm = Pick<
+  Card,
+  "title" | "fontAwesomeIcon" | "description" | "shortDescription" | "linkText" | "link"
+>;
+
+// Seed for a brand-new card; the admin fills in the rest in the same modal.
+const BLANK_CARD: CardForm = {
+  title: "",
+  fontAwesomeIcon: "star",
+  description: "",
+  shortDescription: "",
+  linkText: "Learn more",
+  link: "/"
+};
+
+function cardToForm(card: Card): CardForm {
+  return {
+    title: card.title ?? "",
+    fontAwesomeIcon: card.fontAwesomeIcon ?? "",
+    description: card.description ?? "",
+    shortDescription: card.shortDescription ?? "",
+    linkText: card.linkText ?? "",
+    link: card.link ?? ""
+  };
+}
 
 function CardView({
   card,
@@ -31,15 +62,22 @@ function CardView({
   hidden,
   innerRef,
   onHandlePointerDown,
+  onEdit,
   onToggleHide,
+  onDelete,
   floating
 }: any) {
   // A bad icon name renders nothing (FontAwesome warns); fall back so the slot
-  // never collapses while the admin is typing a new name.
+  // never collapses.
   const iconName = card.fontAwesomeIcon || "star";
 
-  const body = (
-    <>
+  return (
+    <div
+      ref={innerRef}
+      className={`${styles.quickLinkCard} ${isAdmin ? styles.adminCard : ""} ${
+        hidden ? styles.hiddenCard : ""
+      } ${floating ? styles.floating : ""}`}
+    >
       {isAdmin && (
         <div className={styles.adminOverlay}>
           {onHandlePointerDown && (
@@ -52,13 +90,26 @@ function CardView({
               <FontAwesomeIcon icon={faGripVertical} />
             </button>
           )}
+          <button type="button" aria-label="Edit card" title="Edit card" onClick={onEdit}>
+            <FontAwesomeIcon icon={faPen} />
+          </button>
           <button
             type="button"
             className={hidden ? "" : styles.flagActive}
             aria-label={hidden ? "Show card" : "Hide card"}
+            title={hidden ? "Show card" : "Hide card"}
             onClick={onToggleHide}
           >
             <FontAwesomeIcon icon={hidden ? faEyeSlash : faEye} />
+          </button>
+          <button
+            type="button"
+            className={styles.deleteButton}
+            aria-label="Delete card"
+            title="Delete card"
+            onClick={onDelete}
+          >
+            <FontAwesomeIcon icon={faTrash} />
           </button>
         </div>
       )}
@@ -66,59 +117,132 @@ function CardView({
       <div className={styles.quickLinkIcon}>
         <FontAwesomeIcon icon={["fas", iconName]} />
       </div>
-      {isAdmin && (
-        <p className={styles.adminFieldHint}>
-          Icon:{" "}
-          <EditableText model="PortfolioCard" id={card.id} field="fontAwesomeIcon" value={card.fontAwesomeIcon} editable>
-            {card.fontAwesomeIcon}
-          </EditableText>
-        </p>
-      )}
-
-      <h3>
-        <EditableText model="PortfolioCard" id={card.id} field="title" value={card.title} editable={isAdmin}>
-          {card.title}
-        </EditableText>
-      </h3>
-      <p className={styles.description}>
-        <EditableText model="PortfolioCard" id={card.id} field="description" value={card.description} editable={isAdmin} multiline>
-          {card.description}
-        </EditableText>
-      </p>
-      <p className={styles.shortDescription}>
-        <EditableText model="PortfolioCard" id={card.id} field="shortDescription" value={card.shortDescription} editable={isAdmin} multiline>
-          {card.shortDescription}
-        </EditableText>
-      </p>
-
-      {isAdmin ? (
-        <div className={styles.adminLinkBlock}>
-          <span className={styles.linkPreview}>
-            <EditableText model="PortfolioCard" id={card.id} field="linkText" value={card.linkText} editable>
-              {card.linkText}
-            </EditableText>
-          </span>
-          <p className={styles.adminFieldHint}>
-            Links to:{" "}
-            <EditableText model="PortfolioCard" id={card.id} field="link" value={card.link} editable>
-              {card.link}
-            </EditableText>
-          </p>
-        </div>
-      ) : (
-        <Link href={card.link}>{card.linkText}</Link>
-      )}
-    </>
+      <h3>{card.title}</h3>
+      <p className={styles.description}>{card.description}</p>
+      <p className={styles.shortDescription}>{card.shortDescription}</p>
+      <Link href={card.link || "/"}>{card.linkText}</Link>
+    </div>
   );
+}
+
+/**
+ * Modal to create or edit every field of a portfolio card at once, keeping the
+ * card itself clean. Note the two separate descriptions: `description` shows on
+ * large screens, `shortDescription` on small ones.
+ */
+function CardEditor({
+  initial,
+  heading,
+  submitLabel,
+  onSave,
+  onClose
+}: {
+  initial: CardForm;
+  heading: string;
+  submitLabel: string;
+  onSave: (data: CardForm) => Promise<void>;
+  onClose: () => void;
+}) {
+  const [form, setForm] = useState<CardForm>(initial);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  function set<K extends keyof CardForm>(key: K, value: string) {
+    setForm((prev) => ({ ...prev, [key]: value }));
+  }
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setSaving(true);
+    setError("");
+    try {
+      await onSave(form);
+    } catch (err: any) {
+      setError(err?.message || "Failed to save card.");
+      setSaving(false);
+    }
+  }
+
+  const iconName = form.fontAwesomeIcon.trim() || "star";
 
   return (
     <div
-      ref={innerRef}
-      className={`${styles.quickLinkCard} ${isAdmin ? styles.adminCard : ""} ${
-        hidden ? styles.hiddenCard : ""
-      } ${floating ? styles.floating : ""}`}
+      className={styles.modalOverlay}
+      role="dialog"
+      aria-modal="true"
+      aria-label="Edit card"
+      onMouseDown={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
     >
-      {body}
+      <form className={styles.modal} onSubmit={submit}>
+        <h2 className={styles.modalTitle}>{heading}</h2>
+
+        <label className={styles.field}>
+          <span>Title</span>
+          <input value={form.title} onChange={(e) => set("title", e.target.value)} required autoFocus />
+        </label>
+
+        <label className={styles.field}>
+          <span>Icon</span>
+          <div className={styles.iconField}>
+            <span className={styles.iconPreview}>
+              <FontAwesomeIcon icon={["fas", iconName] as any} />
+            </span>
+            <input
+              value={form.fontAwesomeIcon}
+              onChange={(e) => set("fontAwesomeIcon", e.target.value)}
+              placeholder="star"
+            />
+          </div>
+          <small className={styles.fieldHint}>
+            Font Awesome solid icon name, e.g. “star”, “code”, “briefcase”.
+          </small>
+        </label>
+
+        <label className={styles.field}>
+          <span>Description (large screens)</span>
+          <textarea value={form.description} onChange={(e) => set("description", e.target.value)} rows={3} />
+        </label>
+
+        <label className={styles.field}>
+          <span>Short description (small screens)</span>
+          <textarea
+            value={form.shortDescription}
+            onChange={(e) => set("shortDescription", e.target.value)}
+            rows={2}
+          />
+        </label>
+
+        <label className={styles.field}>
+          <span>Link text</span>
+          <input value={form.linkText} onChange={(e) => set("linkText", e.target.value)} />
+        </label>
+
+        <label className={styles.field}>
+          <span>Link destination</span>
+          <input value={form.link} onChange={(e) => set("link", e.target.value)} placeholder="/projects" />
+        </label>
+
+        {error && <p className={styles.modalError}>{error}</p>}
+
+        <div className={styles.modalActions}>
+          <button type="button" className={styles.modalCancel} onClick={onClose} disabled={saving}>
+            Cancel
+          </button>
+          <button type="submit" className={styles.modalConfirm} disabled={saving}>
+            {saving ? "Saving…" : submitLabel}
+          </button>
+        </div>
+      </form>
     </div>
   );
 }
@@ -127,7 +251,11 @@ export default function Portfolio({ className, cards, description, config, isAdm
   const router = useRouter();
   const [cfg, setCfg] = useState<SiteConfigData>(config);
   const [items, setItems] = useState<Card[]>(() => applyConfigToCards(cards, config, isAdmin));
-  const [creating, setCreating] = useState(false);
+  const [showCreate, setShowCreate] = useState(false);
+  const [editing, setEditing] = useState<Card | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<Card | null>(null);
+  const [deleting, setDeleting] = useState(false);
+  const [deleteError, setDeleteError] = useState("");
   const cfgRef = useRef(cfg);
 
   useEffect(() => { cfgRef.current = cfg; }, [cfg]);
@@ -154,17 +282,55 @@ export default function Portfolio({ className, cards, description, config, isAdm
     });
   }
 
-  async function addCard() {
-    setCreating(true);
-    const result = await createPortfolioCard();
-    setCreating(false);
+  async function saveCard(data: CardForm) {
+    const target = editing;
+    if (!target) return;
+    const result = await updatePortfolioCard(target.id, data);
     if ("error" in result) {
-      alert(`Couldn't add card: ${result.error}`);
-    } else {
-      const nextItems = [...items, result.card];
-      setItems(nextItems);
-      persist({ ...cfgRef.current, portfolioCardOrder: nextItems.map((c) => c.id) });
+      throw new Error(result.error);
     }
+    setItems((prev) => prev.map((c) => (c.id === target.id ? { ...c, ...data } : c)));
+    setEditing(null);
+  }
+
+  async function confirmDelete() {
+    const card = pendingDelete;
+    if (!card) return;
+
+    setDeleting(true);
+    setDeleteError("");
+
+    const result = await deletePortfolioCard(card.id);
+    if ("error" in result) {
+      setDeleting(false);
+      setDeleteError(result.error);
+      return;
+    }
+
+    setItems((prev) => prev.filter((c) => c.id !== card.id));
+
+    // Drop the card from siteConfig too (order + flags) so nothing dangles.
+    const nextCards = { ...cfgRef.current.portfolioCards };
+    delete nextCards[card.id];
+    persist({
+      ...cfgRef.current,
+      portfolioCardOrder: cfgRef.current.portfolioCardOrder.filter((x) => x !== card.id),
+      portfolioCards: nextCards
+    });
+
+    setDeleting(false);
+    setPendingDelete(null);
+  }
+
+  async function createCard(data: CardForm) {
+    const result = await createPortfolioCard(data);
+    if ("error" in result) {
+      throw new Error(result.error);
+    }
+    const nextItems = [...items, result.card];
+    setItems(nextItems);
+    await persist({ ...cfgRef.current, portfolioCardOrder: nextItems.map((c) => c.id) });
+    setShowCreate(false);
   }
 
   const drag = useDragReorder<Card>({
@@ -207,7 +373,9 @@ export default function Portfolio({ className, cards, description, config, isAdm
               onHandlePointerDown={
                 isAdmin ? (e: React.PointerEvent) => drag.startDrag(index, card.id, e) : undefined
               }
+              onEdit={() => setEditing(card)}
               onToggleHide={() => toggleHide(card.id)}
+              onDelete={() => { setDeleteError(""); setPendingDelete(card); }}
             />
           )
         )}
@@ -216,11 +384,10 @@ export default function Portfolio({ className, cards, description, config, isAdm
           <button
             type="button"
             className={styles.addCardButton}
-            onClick={addCard}
-            disabled={creating}
+            onClick={() => setShowCreate(true)}
           >
             <FontAwesomeIcon icon={faPlus} />
-            <span>{creating ? "Adding…" : "Add card"}</span>
+            <span>Add card</span>
           </button>
         )}
       </div>
@@ -228,6 +395,66 @@ export default function Portfolio({ className, cards, description, config, isAdm
       {draggingCard && isAdmin && (
         <div className={styles.floatingLayer} style={drag.floatingStyle}>
           <CardView card={draggingCard} isAdmin floating hidden={cardFlags(cfg, draggingCard.id).hidden} />
+        </div>
+      )}
+
+      {editing && (
+        <CardEditor
+          initial={cardToForm(editing)}
+          heading="Edit card"
+          submitLabel="Save"
+          onSave={saveCard}
+          onClose={() => setEditing(null)}
+        />
+      )}
+
+      {showCreate && (
+        <CardEditor
+          initial={BLANK_CARD}
+          heading="New card"
+          submitLabel="Create"
+          onSave={createCard}
+          onClose={() => setShowCreate(false)}
+        />
+      )}
+
+      {pendingDelete && (
+        <div
+          className={styles.modalOverlay}
+          role="dialog"
+          aria-modal="true"
+          aria-label="Delete card"
+          onMouseDown={(e) => {
+            if (e.target === e.currentTarget && !deleting) setPendingDelete(null);
+          }}
+        >
+          <div className={`${styles.modal} ${styles.confirmModal}`}>
+            <h2 className={styles.modalTitle}>Delete card?</h2>
+            <p className={styles.confirmText}>
+              This permanently removes{" "}
+              <strong>{pendingDelete.title?.trim() || "this card"}</strong> from the CMS.
+              This can’t be undone.
+            </p>
+            {deleteError && <p className={styles.modalError}>{deleteError}</p>}
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.modalCancel}
+                onClick={() => setPendingDelete(null)}
+                disabled={deleting}
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                className={styles.modalDanger}
+                onClick={confirmDelete}
+                disabled={deleting}
+              >
+                {deleting ? "Deleting…" : "Delete"}
+              </button>
+            </div>
+          </div>
         </div>
       )}
     </div>

--- a/src/app/(index)/page.tsx
+++ b/src/app/(index)/page.tsx
@@ -76,9 +76,9 @@ export default async function Page() {
   return <>
     <Landing className={`${styles.wrapper} ${styles.homepage}`} description={landingDescription} isAdmin={isAdmin} />
 
-    {config.homepage.showPortfolioCards && (
+    {(config.homepage.showPortfolioCards || isAdmin) && (
       <Portfolio className={`${styles.wrapper} ${styles.welcome}`} cards={portfolioCards}
-                 description={portfolioDescription} isAdmin={isAdmin} />
+                 description={portfolioDescription} config={config} isAdmin={isAdmin} />
     )}
 
     {config.homepage.showFeaturedProjects && (featured.length > 0 || isAdmin) && (

--- a/src/app/(index)/portfolio.module.scss
+++ b/src/app/(index)/portfolio.module.scss
@@ -39,18 +39,22 @@
 }
 
 .quickLinks {
-  display: grid;
+  // Flex (not grid) so each wrapped row centers its own cards — a partially
+  // filled last row stays centered instead of left-packing. The max-width caps
+  // the row at three 300px cards, matching the original column count.
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
   gap: 2rem;
-  margin-top: 4rem;
+  margin: 4rem auto 0;
   padding: 0 1rem;
+  max-width: 1040px;
 
   @media (min-width: 800px) {
-    grid-template-columns: repeat(2, 1fr);
     margin-top: 3rem;
   }
 
   @media (min-width: 1024px) {
-    grid-template-columns: repeat(3, 1fr);
     margin-top: 4rem;
   }
 }
@@ -64,9 +68,9 @@
   transition: all 0.3s ease-in-out;
   border: 1px solid var(--border-color);
 
-  width: 100%;
+  width: 300px;
 
-  max-width: 300px;
+  max-width: 100%;
   min-height: 320px;
   display: flex;
   flex-direction: column;
@@ -85,6 +89,7 @@
   }
 
   @media (max-width: 500px) {
+    width: 100%;
     max-width: 100%;
     min-height: auto;
     display: grid;
@@ -241,18 +246,15 @@
 
 /* --- Admin management ----------------------------------------------------- */
 
-// In admin mode keep a simple vertical layout (skip the mobile grid) so the
-// extra inline-edit captions never collide with the grid areas.
+// The admin card is a faithful preview of the public card; it only needs to be a
+// positioning context for the overlay controls. Editing happens in the modal.
+// The entrance fade-in is disabled here: dragging swaps cards in and out of the
+// DOM, which would otherwise replay the (delayed) animation and make cards appear
+// to vanish mid-drag or on drop. Visitors still get the animated entrance.
 .adminCard {
   position: relative;
-
-  @media (max-width: 500px) {
-    display: flex;
-    flex-direction: column;
-
-    .shortDescription { display: none; }
-    .description { display: inline-block; }
-  }
+  animation: none;
+  opacity: 1;
 }
 
 .adminOverlay {
@@ -262,6 +264,8 @@
   z-index: 3;
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
+  justify-content: flex-end;
   gap: 0.4rem;
 
   button {
@@ -275,6 +279,14 @@
 
     &.flagActive {
       background: $accent;
+    }
+
+    &.deleteButton {
+      background: rgba(0, 0, 0, 0.55);
+
+      &:hover {
+        background: #e5484d;
+      }
     }
   }
 }
@@ -299,29 +311,6 @@
   opacity: 0.5;
 }
 
-.adminFieldHint {
-  font-size: 0.8rem;
-  color: var(--text-muted);
-  margin-block: 0.25rem;
-}
-
-.adminLinkBlock {
-  margin-top: auto;
-  display: flex;
-  flex-direction: column;
-  gap: 0.25rem;
-  align-items: center;
-}
-
-.linkPreview {
-  display: inline-block;
-  background-color: $accent;
-  color: #fff;
-  font-weight: bold;
-  padding: 0.6rem 1rem;
-  border-radius: 5px;
-}
-
 .addCardButton {
   display: flex;
   flex-direction: column;
@@ -329,8 +318,8 @@
   justify-content: center;
   gap: 0.5rem;
   min-height: 320px;
-  width: 100%;
-  max-width: 300px;
+  width: 300px;
+  max-width: 100%;
   border: 2px dashed var(--border-color);
   border-radius: 8px;
   background: transparent;
@@ -358,6 +347,11 @@
 }
 
 .floating {
+  // The float clone mounts fresh mid-drag; without this it would replay the
+  // card's entrance animation (which starts at opacity 0 and, for the first few
+  // cards, waits out a 1s+ delay) and appear to vanish while being dragged.
+  animation: none;
+  opacity: 1;
   transform: rotate(2deg) scale(1.03);
   box-shadow: 0 25px 50px rgba(0, 0, 0, 0.4);
   cursor: grabbing;
@@ -368,4 +362,139 @@
   border-radius: 8px;
   background: var(--bg-secondary);
   max-width: 300px;
+}
+
+/* --- Card edit modal ------------------------------------------------------ */
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 1rem;
+  text-align: left;
+}
+
+.modal {
+  width: 100%;
+  max-width: 460px;
+  max-height: 90vh;
+  overflow-y: auto;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modalTitle {
+  font-size: 1.3rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border: none;
+  padding: 0;
+  margin: 0;
+
+  & > span {
+    font-size: 0.9rem;
+    font-weight: bold;
+    color: var(--text-secondary);
+  }
+
+  input,
+  textarea {
+    width: 100%;
+    padding: 0.6em 0.75em;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5em;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+    font: inherit;
+    resize: vertical;
+  }
+}
+
+.fieldHint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}
+
+.iconField {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+
+  & > input {
+    flex: 1;
+  }
+}
+
+.iconPreview {
+  display: grid;
+  place-items: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: var(--bg-secondary);
+  color: $accent;
+}
+
+.modalError {
+  color: #e5484d;
+  font-size: 0.9rem;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.modalCancel,
+.modalConfirm,
+.modalDanger {
+  padding: 0.6em 1.25em;
+  border: none;
+  border-radius: 0.5em;
+  font-weight: bold;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+}
+
+.modalCancel {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.modalConfirm {
+  background: $accent;
+  color: #fff;
+}
+
+.modalDanger {
+  background: #e5484d;
+  color: #fff;
+}
+
+.confirmModal {
+  max-width: 400px;
+}
+
+.confirmText {
+  color: var(--text-secondary);
+  line-height: 1.5;
 }

--- a/src/app/(index)/portfolio.module.scss
+++ b/src/app/(index)/portfolio.module.scss
@@ -238,3 +238,134 @@
   transform: translateY(-2.5px);
   box-shadow: 0 15px 30px rgba(0, 0, 0, 0.1);
 }
+
+/* --- Admin management ----------------------------------------------------- */
+
+// In admin mode keep a simple vertical layout (skip the mobile grid) so the
+// extra inline-edit captions never collide with the grid areas.
+.adminCard {
+  position: relative;
+
+  @media (max-width: 500px) {
+    display: flex;
+    flex-direction: column;
+
+    .shortDescription { display: none; }
+    .description { display: inline-block; }
+  }
+}
+
+.adminOverlay {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  z-index: 3;
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+
+  button {
+    width: 2rem;
+    height: 2rem;
+    border: none;
+    border-radius: 6px;
+    cursor: pointer;
+    color: #fff;
+    background: rgba(0, 0, 0, 0.55);
+
+    &.flagActive {
+      background: $accent;
+    }
+  }
+}
+
+.dragHandle {
+  display: grid;
+  place-items: center;
+  width: 2rem;
+  height: 2rem;
+  padding: 0;
+  border: none;
+  border-radius: 6px;
+  color: #fff;
+  background: rgba(0, 0, 0, 0.55);
+  cursor: grab;
+  touch-action: none;
+
+  &:active { cursor: grabbing; }
+}
+
+.hiddenCard {
+  opacity: 0.5;
+}
+
+.adminFieldHint {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  margin-block: 0.25rem;
+}
+
+.adminLinkBlock {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  align-items: center;
+}
+
+.linkPreview {
+  display: inline-block;
+  background-color: $accent;
+  color: #fff;
+  font-weight: bold;
+  padding: 0.6rem 1rem;
+  border-radius: 5px;
+}
+
+.addCardButton {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.5rem;
+  min-height: 320px;
+  width: 100%;
+  max-width: 300px;
+  border: 2px dashed var(--border-color);
+  border-radius: 8px;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  transition: all 0.2s ease-in-out;
+
+  svg { font-size: 1.75rem; }
+
+  &:hover:not(:disabled) {
+    border-color: $accent;
+    color: var(--text-primary);
+  }
+
+  &:disabled { opacity: 0.6; cursor: default; }
+}
+
+.floatingLayer {
+  position: fixed;
+  z-index: 1000;
+  pointer-events: none;
+  margin: 0;
+  list-style: none;
+}
+
+.floating {
+  transform: rotate(2deg) scale(1.03);
+  box-shadow: 0 25px 50px rgba(0, 0, 0, 0.4);
+  cursor: grabbing;
+}
+
+.placeholder {
+  border: 2px dashed var(--border-color);
+  border-radius: 8px;
+  background: var(--bg-secondary);
+  max-width: 300px;
+}

--- a/src/app/admin/contentActions.ts
+++ b/src/app/admin/contentActions.ts
@@ -498,15 +498,24 @@ const PUBLISH_PROJECT_MUTATION = `
 
 type CreateProjectResult = { ok: true; id: string; slug: string } | { ok: false; error: string };
 
+// Placeholder text fields a fresh project gets so the (required) CMS fields are
+// satisfied; the admin overwrites them inline. An empty paragraph keeps the
+// rich-text body valid so the project page (which reads `projectPageContent.raw`)
+// renders right after the post-create redirect.
+const NEW_PROJECT_DESCRIPTION = "Add a description for this project.";
+const EMPTY_RICH_TEXT = { children: [{ type: "paragraph", children: [{ text: "" }] }] };
+
 /**
- * Create a minimal project stub (title, slug, type) and publish it. The admin
- * fills in image/description/rich-text inline afterward. Slug is lowercased to
- * match how project pages look themselves up (see projects/[slug]/page.tsx).
+ * Create a minimal project stub (title, slug, type) and publish it. Required text
+ * fields get placeholders the admin overwrites inline afterward (image too). Slug
+ * is lowercased to match how project pages look themselves up (see
+ * projects/[slug]/page.tsx).
  */
 export async function createProject(
   title: string,
   slug: string,
-  projectType: string[]
+  projectType: string[],
+  imageId: string
 ): Promise<CreateProjectResult> {
   if (!(await isAuthed())) {
     return { ok: false, error: "Not authorized." };
@@ -521,15 +530,28 @@ export async function createProject(
   if (!/^[a-z0-9-]+$/.test(cleanSlug)) {
     return { ok: false, error: "Slug may only contain lowercase letters, numbers, and hyphens." };
   }
+  if (!imageId) {
+    return { ok: false, error: "An image is required." };
+  }
 
   try {
     const data = await cmsMutate(CREATE_PROJECT_MUTATION, {
-      data: { title: cleanTitle, slug: cleanSlug, projectType }
+      data: {
+        title: cleanTitle,
+        slug: cleanSlug,
+        projectType,
+        description: NEW_PROJECT_DESCRIPTION,
+        projectPageDescription: NEW_PROJECT_DESCRIPTION,
+        projectPageContent: EMPTY_RICH_TEXT,
+        image: { connect: { id: imageId } }
+      }
     });
     const project = data?.createProject;
     if (!project?.id) {
       return { ok: false, error: "Project was not created." };
     }
+    // Publish the asset too, so the connected image resolves on the public stage.
+    await cmsMutate(PUBLISH_ASSET_MUTATION, { id: imageId });
     await cmsMutate(PUBLISH_PROJECT_MUTATION, { id: project.id });
     return { ok: true, id: project.id, slug: project.slug };
   } catch (e: any) {

--- a/src/app/admin/contentActions.ts
+++ b/src/app/admin/contentActions.ts
@@ -362,17 +362,6 @@ const PORTFOLIO_CARD_FIELDS = `
   link
 `;
 
-// Sensible starter content so a freshly created card renders immediately and is
-// obviously a placeholder the admin then edits inline.
-const NEW_CARD_DEFAULTS = {
-  title: "New Card",
-  fontAwesomeIcon: "star",
-  description: "Describe this section of your portfolio.",
-  shortDescription: "",
-  linkText: "Learn more",
-  link: "/"
-};
-
 const CREATE_PORTFOLIO_CARD_MUTATION = `
   mutation CreatePortfolioCard($data: PortfolioCardCreateInput!) {
     createPortfolioCard(data: $data) {
@@ -387,22 +376,67 @@ const PUBLISH_PORTFOLIO_CARD_MUTATION = `
   }
 `;
 
-type CreateCardResult = { ok: true; card: PortfolioCard } | { ok: false; error: string };
+const UNPUBLISH_PORTFOLIO_CARD_MUTATION = `
+  mutation UnpublishPortfolioCard($id: ID!) {
+    unpublishPortfolioCard(where: { id: $id }, from: PUBLISHED) { id }
+  }
+`;
+
+const DELETE_PORTFOLIO_CARD_MUTATION = `
+  mutation DeletePortfolioCard($id: ID!) {
+    deletePortfolioCard(where: { id: $id }) { id }
+  }
+`;
 
 /**
- * Create a new portfolio card (with placeholder content) and publish it so it
- * shows on the homepage right away. Returns the full card so the client can
- * append it and order it without a refetch. Visibility/order are tracked in
- * siteConfig by the caller.
+ * Permanently delete a portfolio card. A published card must be unpublished first,
+ * so we always attempt an unpublish (ignoring the error when it isn't published)
+ * before deleting. Irreversible — the UI confirms with the user beforehand. The
+ * caller also drops the card from siteConfig (order + flags).
  */
-export async function createPortfolioCard(): Promise<CreateCardResult> {
+export async function deletePortfolioCard(id: string): Promise<ActionResult> {
   if (!(await isAuthed())) {
     return { ok: false, error: "Not authorized." };
   }
 
   try {
-    const data = await cmsMutate(CREATE_PORTFOLIO_CARD_MUTATION, { data: NEW_CARD_DEFAULTS });
-    const card = data?.createPortfolioCard;
+    try {
+      await cmsMutate(UNPUBLISH_PORTFOLIO_CARD_MUTATION, { id });
+    } catch {
+      // Not published (or already unpublished) — nothing to undo before delete.
+    }
+    await cmsMutate(DELETE_PORTFOLIO_CARD_MUTATION, { id });
+  } catch (e: any) {
+    return { ok: false, error: e?.message || "Failed to delete card." };
+  }
+
+  return { ok: true };
+}
+
+type CreateCardResult = { ok: true; card: PortfolioCard } | { ok: false; error: string };
+
+/**
+ * Create a new portfolio card from the admin's form values and publish it so it
+ * shows on the homepage right away. Fields are filtered against the PortfolioCard
+ * whitelist. Returns the full card so the client can append + order it without a
+ * refetch. Visibility/order are tracked in siteConfig by the caller.
+ */
+export async function createPortfolioCard(
+  data: Record<string, string>
+): Promise<CreateCardResult> {
+  if (!(await isAuthed())) {
+    return { ok: false, error: "Not authorized." };
+  }
+
+  const allowed = EDITABLE_FIELDS.PortfolioCard;
+  const clean: Record<string, string> = {};
+  for (const key of allowed) {
+    if (typeof data?.[key] === "string") clean[key] = data[key];
+  }
+
+  try {
+    const result = await cmsMutate(CREATE_PORTFOLIO_CARD_MUTATION, { data: clean });
+    const card = result?.createPortfolioCard;
     if (!card?.id) {
       return { ok: false, error: "Card was not created." };
     }
@@ -411,6 +445,41 @@ export async function createPortfolioCard(): Promise<CreateCardResult> {
   } catch (e: any) {
     return { ok: false, error: e?.message || "Failed to create card." };
   }
+}
+
+const UPDATE_PORTFOLIO_CARD_MUTATION = `
+  mutation UpdatePortfolioCard($id: ID!, $data: PortfolioCardUpdateInput!) {
+    updatePortfolioCard(where: { id: $id }, data: $data) { id }
+  }
+`;
+
+/**
+ * Update any subset of a portfolio card's editable fields in one write, then
+ * publish. Fields are filtered against the PortfolioCard whitelist, so only the
+ * known simple fields are ever sent. Backs the card edit modal.
+ */
+export async function updatePortfolioCard(
+  id: string,
+  data: Record<string, string>
+): Promise<ActionResult> {
+  if (!(await isAuthed())) {
+    return { ok: false, error: "Not authorized." };
+  }
+
+  const allowed = EDITABLE_FIELDS.PortfolioCard;
+  const clean: Record<string, string> = {};
+  for (const key of allowed) {
+    if (typeof data?.[key] === "string") clean[key] = data[key];
+  }
+
+  try {
+    await cmsMutate(UPDATE_PORTFOLIO_CARD_MUTATION, { id, data: clean });
+    await cmsMutate(PUBLISH_PORTFOLIO_CARD_MUTATION, { id });
+  } catch (e: any) {
+    return { ok: false, error: e?.message || "Failed to update card." };
+  }
+
+  return { ok: true };
 }
 
 // --- Projects ----------------------------------------------------------------

--- a/src/app/admin/contentActions.ts
+++ b/src/app/admin/contentActions.ts
@@ -14,9 +14,9 @@ type ActionResult = { ok: true } | { ok: false; error: string };
 // model API IDs (singular, PascalCase); they're interpolated into mutation names
 // so only these exact values are ever used.
 const EDITABLE_FIELDS: Record<string, string[]> = {
-  Project: ["title", "description", "tags", "projectPageDescription"],
+  Project: ["title", "description", "tags", "projectPageDescription", "projectType"],
   Description: ["header", "description"],
-  PortfolioCard: ["title", "description", "shortDescription", "linkText"]
+  PortfolioCard: ["title", "description", "shortDescription", "linkText", "link", "fontAwesomeIcon"]
 };
 
 // Rich-text (RichTextAST) fields the inline editor may write. Kept separate from
@@ -338,4 +338,160 @@ export async function listMediaAssets(): Promise<ListAssetsResult> {
   } catch (e: any) {
     return { error: e?.message || "Failed to load media." };
   }
+}
+
+// --- Portfolio cards ---------------------------------------------------------
+
+export type PortfolioCard = {
+  id: string;
+  title: string;
+  fontAwesomeIcon: string;
+  description: string;
+  shortDescription: string;
+  linkText: string;
+  link: string;
+};
+
+const PORTFOLIO_CARD_FIELDS = `
+  id
+  title
+  fontAwesomeIcon
+  description
+  shortDescription
+  linkText
+  link
+`;
+
+// Sensible starter content so a freshly created card renders immediately and is
+// obviously a placeholder the admin then edits inline.
+const NEW_CARD_DEFAULTS = {
+  title: "New Card",
+  fontAwesomeIcon: "star",
+  description: "Describe this section of your portfolio.",
+  shortDescription: "",
+  linkText: "Learn more",
+  link: "/"
+};
+
+const CREATE_PORTFOLIO_CARD_MUTATION = `
+  mutation CreatePortfolioCard($data: PortfolioCardCreateInput!) {
+    createPortfolioCard(data: $data) {
+      ${PORTFOLIO_CARD_FIELDS}
+    }
+  }
+`;
+
+const PUBLISH_PORTFOLIO_CARD_MUTATION = `
+  mutation PublishPortfolioCard($id: ID!) {
+    publishPortfolioCard(where: { id: $id }, to: PUBLISHED) { id }
+  }
+`;
+
+type CreateCardResult = { ok: true; card: PortfolioCard } | { ok: false; error: string };
+
+/**
+ * Create a new portfolio card (with placeholder content) and publish it so it
+ * shows on the homepage right away. Returns the full card so the client can
+ * append it and order it without a refetch. Visibility/order are tracked in
+ * siteConfig by the caller.
+ */
+export async function createPortfolioCard(): Promise<CreateCardResult> {
+  if (!(await isAuthed())) {
+    return { ok: false, error: "Not authorized." };
+  }
+
+  try {
+    const data = await cmsMutate(CREATE_PORTFOLIO_CARD_MUTATION, { data: NEW_CARD_DEFAULTS });
+    const card = data?.createPortfolioCard;
+    if (!card?.id) {
+      return { ok: false, error: "Card was not created." };
+    }
+    await cmsMutate(PUBLISH_PORTFOLIO_CARD_MUTATION, { id: card.id });
+    return { ok: true, card };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || "Failed to create card." };
+  }
+}
+
+// --- Projects ----------------------------------------------------------------
+
+const CREATE_PROJECT_MUTATION = `
+  mutation CreateProject($data: ProjectCreateInput!) {
+    createProject(data: $data) { id slug }
+  }
+`;
+
+const PUBLISH_PROJECT_MUTATION = `
+  mutation PublishProject($id: ID!) {
+    publishProject(where: { id: $id }, to: PUBLISHED) { id }
+  }
+`;
+
+type CreateProjectResult = { ok: true; id: string; slug: string } | { ok: false; error: string };
+
+/**
+ * Create a minimal project stub (title, slug, type) and publish it. The admin
+ * fills in image/description/rich-text inline afterward. Slug is lowercased to
+ * match how project pages look themselves up (see projects/[slug]/page.tsx).
+ */
+export async function createProject(
+  title: string,
+  slug: string,
+  projectType: string[]
+): Promise<CreateProjectResult> {
+  if (!(await isAuthed())) {
+    return { ok: false, error: "Not authorized." };
+  }
+
+  const cleanTitle = title.trim();
+  const cleanSlug = slug.trim().toLowerCase();
+
+  if (!cleanTitle || !cleanSlug) {
+    return { ok: false, error: "Title and slug are required." };
+  }
+  if (!/^[a-z0-9-]+$/.test(cleanSlug)) {
+    return { ok: false, error: "Slug may only contain lowercase letters, numbers, and hyphens." };
+  }
+
+  try {
+    const data = await cmsMutate(CREATE_PROJECT_MUTATION, {
+      data: { title: cleanTitle, slug: cleanSlug, projectType }
+    });
+    const project = data?.createProject;
+    if (!project?.id) {
+      return { ok: false, error: "Project was not created." };
+    }
+    await cmsMutate(PUBLISH_PROJECT_MUTATION, { id: project.id });
+    return { ok: true, id: project.id, slug: project.slug };
+  } catch (e: any) {
+    return { ok: false, error: e?.message || "Failed to create project." };
+  }
+}
+
+const SET_PROJECT_IMAGE_MUTATION = `
+  mutation SetProjectImage($id: ID!, $assetId: ID!) {
+    updateProject(where: { id: $id }, data: { image: { connect: { id: $assetId } } }) { id }
+  }
+`;
+
+/**
+ * Point a project's `image` relation at an existing media asset, then publish
+ * both: the asset must be published for the public (PUBLISHED-stage) read to
+ * resolve its URL. Replaces any current image (to-one relation).
+ */
+export async function setProjectImage(id: string, assetId: string): Promise<ActionResult> {
+  if (!(await isAuthed())) {
+    return { ok: false, error: "Not authorized." };
+  }
+
+  try {
+    await cmsMutate(SET_PROJECT_IMAGE_MUTATION, { id, assetId });
+    // Make sure the linked asset is live, otherwise `image { url }` is null publicly.
+    await cmsMutate(PUBLISH_ASSET_MUTATION, { id: assetId });
+    await cmsMutate(PUBLISH_PROJECT_MUTATION, { id });
+  } catch (e: any) {
+    return { ok: false, error: e?.message || "Failed to set project image." };
+  }
+
+  return { ok: true };
 }

--- a/src/app/projects/Projects.tsx
+++ b/src/app/projects/Projects.tsx
@@ -6,19 +6,120 @@ import Image from "next/image";
 import { useEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faTag, faStar, faEye, faEyeSlash, faGripVertical } from "@fortawesome/free-solid-svg-icons";
+import {
+  faTag,
+  faStar,
+  faEye,
+  faEyeSlash,
+  faGripVertical,
+  faBoxArchive,
+  faRotateLeft,
+  faImage,
+  faPlus,
+  faXmark
+} from "@fortawesome/free-solid-svg-icons";
 import EditableText from "@/components/EditableText";
+import AssetPicker from "@/components/RichTextEditor/AssetPicker";
 import { useDragReorder } from "@/components/useDragReorder";
-import { saveConfig } from "@/app/admin/contentActions";
+import {
+  saveConfig,
+  updateContentField,
+  createProject,
+  setProjectImage
+} from "@/app/admin/contentActions";
 import { projectFlags, type SiteConfigData } from "@/lib/siteConfig";
 
-function ProjectCard({ project, priority, isAdmin, flags, onToggle, onHandlePointerDown, innerRef, floating }: any) {
+/**
+ * Tag pills for a project. Visitors see the original read-only chip list; admins
+ * get the same chips with a per-tag remove (×) plus an inline "add tag" input.
+ * Tags stay a plain string array on the Project (no Tag entity) — `onChange`
+ * persists the full next array.
+ */
+function TagEditor({ project, isAdmin, onChange }: any) {
+  const [draft, setDraft] = useState("");
+
+  if (!isAdmin) {
+    return (
+      <ul>
+        {project.tags.map((tag: string) => (
+          <li key={tag}><FontAwesomeIcon icon={faTag} />{tag}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  function addTag() {
+    const value = draft.trim();
+    setDraft("");
+    if (!value || project.tags.includes(value)) return;
+    onChange(project, [...project.tags, value]);
+  }
+
+  function removeTag(tag: string) {
+    onChange(project, project.tags.filter((t: string) => t !== tag));
+  }
+
+  return (
+    <ul className={styles.tagEditorList}>
+      {project.tags.map((tag: string) => (
+        <li key={tag}>
+          <FontAwesomeIcon icon={faTag} />{tag}
+          <button
+            type="button"
+            className={styles.tagRemove}
+            aria-label={`Remove tag ${tag}`}
+            onClick={() => removeTag(tag)}
+          >
+            <FontAwesomeIcon icon={faXmark} />
+          </button>
+        </li>
+      ))}
+      <li className={styles.tagInputChip}>
+        <input
+          className={styles.tagInput}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addTag();
+            } else if (e.key === "Backspace" && draft === "" && project.tags.length) {
+              removeTag(project.tags[project.tags.length - 1]);
+            }
+          }}
+          onBlur={addTag}
+          placeholder="Add tag…"
+          aria-label="Add tag"
+        />
+      </li>
+    </ul>
+  );
+}
+
+function ProjectCard({
+  project,
+  priority,
+  isAdmin,
+  flags,
+  enumValues,
+  onToggle,
+  onArchive,
+  onEditImage,
+  onToggleType,
+  onTagsChange,
+  onHandlePointerDown,
+  innerRef,
+  floating
+}: any) {
   const hidden = isAdmin && !flags.visible;
+  const archived = isAdmin && flags.archived;
 
   return (
     <div
       ref={innerRef}
-      className={`${styles.card} ${hidden ? styles.hiddenCard : ""} ${floating ? styles.floating : ""}`}
+      className={`${styles.card} ${hidden ? styles.hiddenCard : ""} ${
+        archived ? styles.archivedCard : ""
+      } ${floating ? styles.floating : ""}`}
     >
       <div className={styles.thumbnail}>
         {project.image && (
@@ -47,6 +148,14 @@ function ProjectCard({ project, priority, isAdmin, flags, onToggle, onHandlePoin
             )}
             <button
               type="button"
+              aria-label="Change image"
+              title="Change image"
+              onClick={() => onEditImage(project)}
+            >
+              <FontAwesomeIcon icon={faImage} />
+            </button>
+            <button
+              type="button"
               className={flags.featured ? styles.flagActive : ""}
               aria-label="Toggle featured"
               onClick={() => onToggle(project.slug, "featured")}
@@ -60,6 +169,15 @@ function ProjectCard({ project, priority, isAdmin, flags, onToggle, onHandlePoin
               onClick={() => onToggle(project.slug, "visible")}
             >
               <FontAwesomeIcon icon={flags.visible ? faEye : faEyeSlash} />
+            </button>
+            <button
+              type="button"
+              className={archived ? styles.flagActive : ""}
+              aria-label={archived ? "Restore project" : "Archive project"}
+              title={archived ? "Restore project" : "Archive project"}
+              onClick={() => onArchive(project.slug, !archived)}
+            >
+              <FontAwesomeIcon icon={archived ? faRotateLeft : faBoxArchive} />
             </button>
           </div>
         )}
@@ -77,11 +195,25 @@ function ProjectCard({ project, priority, isAdmin, flags, onToggle, onHandlePoin
           </EditableText>
         </p>
 
-        <ul>
-          {project.tags.map(tag => (
-            <li key={tag}><FontAwesomeIcon icon={faTag} />{tag}</li>
-          ))}
-        </ul>
+        <TagEditor project={project} isAdmin={isAdmin} onChange={onTagsChange} />
+
+        {isAdmin && (
+          <div className={styles.typeChips}>
+            {enumValues.map((type: any) => {
+              const active = project.projectType.includes(type.name);
+              return (
+                <button
+                  key={type.name}
+                  type="button"
+                  className={`${styles.typeChip} ${active ? styles.typeChipActive : ""}`}
+                  onClick={() => onToggleType(project, type.name)}
+                >
+                  {camelCaseToSentence(type.name)}
+                </button>
+              );
+            })}
+          </div>
+        )}
 
         <Link href={`/projects/${project.slug}`}>View Details</Link>
       </div>
@@ -92,11 +224,21 @@ function ProjectCard({ project, priority, isAdmin, flags, onToggle, onHandlePoin
 export default function Projects({ projects, config, isAdmin = false }: any) {
   const router = useRouter();
   const searchParams = useSearchParams();
+  const enumValues = projects["__type"].enumValues;
 
   const [projectType, setProjectType] = useState<string>("all");
   const [items, setItems] = useState<any[]>(projects.projects);
   const [cfg, setCfg] = useState<SiteConfigData>(config);
   const cfgRef = useRef(cfg);
+
+  // Image picker (project being re-imaged) and the New Project modal.
+  const [imageFor, setImageFor] = useState<any | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [newSlug, setNewSlug] = useState("");
+  const [newTypes, setNewTypes] = useState<string[]>([]);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState("");
 
   useEffect(() => setItems(projects.projects), [projects.projects]);
   useEffect(() => setCfg(config), [config]);
@@ -107,11 +249,11 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
 
     function isValidProjectType() {
       return queriedProjectType &&
-             projects["__type"].enumValues.some((enumType: any) => enumType.name === queriedProjectType)
+             enumValues.some((enumType: any) => enumType.name === queriedProjectType)
     }
 
-    setProjectType(isValidProjectType() ? queriedProjectType : "all");
-  }, [searchParams, projects]);
+    setProjectType(isValidProjectType() ? queriedProjectType! : "all");
+  }, [searchParams, enumValues]);
 
   function changeProjectType(type: string) {
     const url = type === "all" ? "/projects" : `?projectType=${type}`;
@@ -133,11 +275,70 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
   }
 
   function toggleFlag(slug: string, key: "visible" | "featured") {
-    const current = projectFlags(cfg, slug);
+    const current = projectFlags(cfgRef.current, slug);
     persist({
-      ...cfg,
-      projects: { ...cfg.projects, [slug]: { ...current, [key]: !current[key] } }
+      ...cfgRef.current,
+      projects: { ...cfgRef.current.projects, [slug]: { ...current, [key]: !current[key] } }
     });
+  }
+
+  function setArchived(slug: string, archived: boolean) {
+    const current = projectFlags(cfgRef.current, slug);
+    persist({
+      ...cfgRef.current,
+      projects: { ...cfgRef.current.projects, [slug]: { ...current, archived } }
+    });
+  }
+
+  async function toggleType(project: any, typeName: string) {
+    const has = project.projectType.includes(typeName);
+    const next = has
+      ? project.projectType.filter((t: string) => t !== typeName)
+      : [...project.projectType, typeName];
+
+    setItems((prev) => prev.map((p) => (p.slug === project.slug ? { ...p, projectType: next } : p)));
+    const result = await updateContentField("Project", project.id, "projectType", next);
+    if ("error" in result) {
+      alert(`Save failed: ${result.error}`);
+      router.refresh();
+    }
+  }
+
+  async function setTags(project: any, next: string[]) {
+    setItems((prev) => prev.map((p) => (p.slug === project.slug ? { ...p, tags: next } : p)));
+    const result = await updateContentField("Project", project.id, "tags", next);
+    if ("error" in result) {
+      alert(`Save failed: ${result.error}`);
+      router.refresh();
+    }
+  }
+
+  async function chooseImage(asset: any) {
+    const target = imageFor;
+    setImageFor(null);
+    if (!target) return;
+
+    setItems((prev) => prev.map((p) => (p.id === target.id ? { ...p, image: { url: asset.url } } : p)));
+    const result = await setProjectImage(target.id, asset.id);
+    if ("error" in result) {
+      alert(`Couldn't set image: ${result.error}`);
+      router.refresh();
+    }
+  }
+
+  async function submitCreate(e: React.FormEvent) {
+    e.preventDefault();
+    setCreating(true);
+    setCreateError("");
+    const result = await createProject(newTitle, newSlug, newTypes);
+    if ("error" in result) {
+      setCreating(false);
+      setCreateError(result.error);
+    } else {
+      // Track it in the admin's order, then open it for inline fill-in.
+      await persist({ ...cfgRef.current, projectOrder: [...cfgRef.current.projectOrder, result.slug] });
+      router.push(`/projects/${result.slug}`);
+    }
   }
 
   const drag = useDragReorder({
@@ -147,7 +348,12 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
     onCommit: (slugs) => persist({ ...cfgRef.current, projectOrder: slugs })
   });
 
-  const visible = items.filter(
+  // Archived projects (admin only) are pulled out into their own section.
+  const archivedItems = isAdmin
+    ? items.filter((p) => projectFlags(cfg, p.slug).archived)
+    : [];
+  const activeItems = items.filter((p) => !projectFlags(cfg, p.slug).archived);
+  const visible = activeItems.filter(
     project => projectType === "all" || project.projectType.includes(projectType)
   );
 
@@ -160,7 +366,7 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
                 onClick={() => changeProjectType("all")}>
           All Projects
         </button>
-        {projects["__type"].enumValues
+        {enumValues
           .map((type : any) => (
             <button key={type.name} className={projectType === type.name ? styles.selectedProjectType : ""}
               onClick={()=> changeProjectType(type.name)}>
@@ -169,8 +375,16 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
           ))}
       </div>
 
+      {isAdmin && (
+        <div className={styles.adminToolbar}>
+          <button type="button" className={styles.newProjectButton} onClick={() => setShowCreate(true)}>
+            <FontAwesomeIcon icon={faPlus} /> New Project
+          </button>
+        </div>
+      )}
+
       <div className={styles.cards}>
-        {visible.map((project, index) => (
+        {visible.map((project) => (
           project.slug === drag.draggingKey ? (
             // The lifted card leaves a gap here; the real card floats by the cursor.
             <div key={project.slug} className={styles.placeholder} style={{ height: drag.size.h }} />
@@ -179,17 +393,44 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
               project={project}
               key={project.slug}
               innerRef={drag.registerCard(project.slug)}
-              priority={index < 3}
+              priority={items.indexOf(project) < 3}
               isAdmin={isAdmin}
               flags={projectFlags(cfg, project.slug)}
+              enumValues={enumValues}
               onToggle={toggleFlag}
+              onArchive={setArchived}
+              onEditImage={setImageFor}
+              onToggleType={toggleType}
+              onTagsChange={setTags}
               onHandlePointerDown={
-                canReorder ? (e: React.PointerEvent) => drag.startDrag(index, project.slug, e) : undefined
+                canReorder ? (e: React.PointerEvent) => drag.startDrag(items.indexOf(project), project.slug, e) : undefined
               }
             />
           )
         ))}
       </div>
+
+      {isAdmin && archivedItems.length > 0 && (
+        <details className={styles.archivedSection}>
+          <summary>Archived projects ({archivedItems.length})</summary>
+          <div className={styles.cards}>
+            {archivedItems.map((project) => (
+              <ProjectCard
+                project={project}
+                key={project.slug}
+                isAdmin={isAdmin}
+                flags={projectFlags(cfg, project.slug)}
+                enumValues={enumValues}
+                onToggle={toggleFlag}
+                onArchive={setArchived}
+                onEditImage={setImageFor}
+                onToggleType={toggleType}
+                onTagsChange={setTags}
+              />
+            ))}
+          </div>
+        </details>
+      )}
 
       {draggingProject && (
         <div className={styles.floatingLayer} style={drag.floatingStyle}>
@@ -197,9 +438,84 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
             project={draggingProject}
             isAdmin={isAdmin}
             flags={projectFlags(cfg, draggingProject.slug)}
+            enumValues={enumValues}
             onToggle={() => {}}
+            onArchive={() => {}}
+            onEditImage={() => {}}
+            onToggleType={() => {}}
+            onTagsChange={() => {}}
             floating
           />
+        </div>
+      )}
+
+      {imageFor && (
+        <AssetPicker
+          title="Set project image"
+          onSelect={chooseImage}
+          onClose={() => setImageFor(null)}
+        />
+      )}
+
+      {showCreate && (
+        <div className={styles.modalOverlay} role="dialog" aria-modal="true" aria-label="New project">
+          <form className={styles.modal} onSubmit={submitCreate}>
+            <h2 className={styles.modalTitle}>New Project</h2>
+
+            <label className={styles.field}>
+              <span>Title</span>
+              <input value={newTitle} onChange={(e) => setNewTitle(e.target.value)} required autoFocus />
+            </label>
+
+            <label className={styles.field}>
+              <span>Slug</span>
+              <input
+                value={newSlug}
+                onChange={(e) => setNewSlug(e.target.value)}
+                placeholder="my-project"
+                required
+              />
+            </label>
+
+            <fieldset className={styles.field}>
+              <span>Type</span>
+              <div className={styles.typeChips}>
+                {enumValues.map((type: any) => {
+                  const active = newTypes.includes(type.name);
+                  return (
+                    <button
+                      key={type.name}
+                      type="button"
+                      className={`${styles.typeChip} ${active ? styles.typeChipActive : ""}`}
+                      onClick={() =>
+                        setNewTypes((prev) =>
+                          active ? prev.filter((t) => t !== type.name) : [...prev, type.name]
+                        )
+                      }
+                    >
+                      {camelCaseToSentence(type.name)}
+                    </button>
+                  );
+                })}
+              </div>
+            </fieldset>
+
+            {createError && <p className={styles.modalError}>{createError}</p>}
+
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.modalCancel}
+                onClick={() => setShowCreate(false)}
+                disabled={creating}
+              >
+                Cancel
+              </button>
+              <button type="submit" className={styles.modalConfirm} disabled={creating}>
+                {creating ? "Creating…" : "Create & edit"}
+              </button>
+            </div>
+          </form>
         </div>
       )}
     </div>

--- a/src/app/projects/Projects.tsx
+++ b/src/app/projects/Projects.tsx
@@ -237,6 +237,8 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
   const [newTitle, setNewTitle] = useState("");
   const [newSlug, setNewSlug] = useState("");
   const [newTypes, setNewTypes] = useState<string[]>([]);
+  const [newImage, setNewImage] = useState<{ id: string; url: string } | null>(null);
+  const [newImagePicker, setNewImagePicker] = useState(false);
   const [creating, setCreating] = useState(false);
   const [createError, setCreateError] = useState("");
 
@@ -328,9 +330,13 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
 
   async function submitCreate(e: React.FormEvent) {
     e.preventDefault();
+    if (!newImage) {
+      setCreateError("Please choose an image.");
+      return;
+    }
     setCreating(true);
     setCreateError("");
-    const result = await createProject(newTitle, newSlug, newTypes);
+    const result = await createProject(newTitle, newSlug, newTypes, newImage.id);
     if ("error" in result) {
       setCreating(false);
       setCreateError(result.error);
@@ -457,6 +463,17 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
         />
       )}
 
+      {newImagePicker && (
+        <AssetPicker
+          title="Choose project image"
+          onSelect={(asset) => {
+            setNewImage({ id: asset.id, url: asset.url });
+            setNewImagePicker(false);
+          }}
+          onClose={() => setNewImagePicker(false)}
+        />
+      )}
+
       {showCreate && (
         <div className={styles.modalOverlay} role="dialog" aria-modal="true" aria-label="New project">
           <form className={styles.modal} onSubmit={submitCreate}>
@@ -500,13 +517,37 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
               </div>
             </fieldset>
 
+            <div className={styles.field}>
+              <span>Image</span>
+              <button
+                type="button"
+                className={styles.imageChoice}
+                onClick={() => setNewImagePicker(true)}
+              >
+                {newImage ? (
+                  <img src={newImage.url} alt="Selected project image" />
+                ) : (
+                  <span className={styles.imageChoicePlaceholder}>
+                    <FontAwesomeIcon icon={faImage} /> Choose image
+                  </span>
+                )}
+              </button>
+            </div>
+
             {createError && <p className={styles.modalError}>{createError}</p>}
 
             <div className={styles.modalActions}>
               <button
                 type="button"
                 className={styles.modalCancel}
-                onClick={() => setShowCreate(false)}
+                onClick={() => {
+                  setShowCreate(false);
+                  setNewTitle("");
+                  setNewSlug("");
+                  setNewTypes([]);
+                  setNewImage(null);
+                  setCreateError("");
+                }}
                 disabled={creating}
               >
                 Cancel

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -85,8 +85,9 @@ export default async function Page({ params }) {
     isAuthed()
   ]);
 
-  // Hidden projects are reachable only while in admin mode.
-  if (!isAdmin && !projectFlags(config, slug.toLowerCase()).visible) {
+  // Hidden or archived projects are reachable only while in admin mode.
+  const flags = projectFlags(config, slug.toLowerCase());
+  if (!isAdmin && (!flags.visible || flags.archived)) {
     notFound();
   }
 

--- a/src/app/projects/projects.module.scss
+++ b/src/app/projects/projects.module.scss
@@ -447,6 +447,38 @@
   }
 }
 
+.imageChoice {
+  display: block;
+  width: 100%;
+  aspect-ratio: 2 / 1;
+  border: 1px dashed var(--border-color);
+  border-radius: 0.5em;
+  background: var(--bg-primary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  overflow: hidden;
+  padding: 0;
+
+  & > img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+  }
+
+  &:hover {
+    border-color: $accent;
+  }
+}
+
+.imageChoicePlaceholder {
+  display: grid;
+  place-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  height: 100%;
+}
+
 .modalError {
   color: #e5484d;
   font-size: 0.9rem;

--- a/src/app/projects/projects.module.scss
+++ b/src/app/projects/projects.module.scss
@@ -231,6 +231,8 @@
   z-index: 3;
   display: flex;
   align-items: center;
+  justify-content: flex-end;
+  flex-wrap: wrap;
   gap: 0.4rem;
 
   button {
@@ -264,4 +266,218 @@
   &:active {
     cursor: grabbing;
   }
+}
+
+.archivedCard {
+  opacity: 0.55;
+}
+
+/* --- Inline tag editor (chips keep the base `.cardContainer > ul > li` pill) -- */
+
+.tagEditorList {
+  & > .tagInputChip {
+    // Neutralize the pill styling for the "add tag" slot.
+    background-color: transparent;
+    padding-inline: 0;
+    height: auto;
+  }
+}
+
+.tagRemove {
+  display: inline-grid;
+  place-items: center;
+  width: 1.05rem;
+  height: 1.05rem;
+  padding: 0;
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: var(--text-muted);
+  cursor: pointer;
+  font-size: 0.85em;
+  transition: all 0.15s ease-in-out;
+
+  &:hover {
+    background: rgba(0, 0, 0, 0.18);
+    color: var(--text-primary);
+  }
+}
+
+.tagInput {
+  width: 7rem;
+  height: 1.75rem;
+  border: 1px dashed var(--border-color);
+  border-radius: 1em;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  padding-inline: 0.75em;
+  font-size: 0.8rem;
+
+  &::placeholder {
+    color: var(--text-muted);
+  }
+
+  &:focus {
+    outline: none;
+    border-style: solid;
+    border-color: $accent;
+  }
+}
+
+/* --- Admin toolbar + New Project ------------------------------------------ */
+
+.adminToolbar {
+  display: flex;
+  justify-content: center;
+  padding-block: 0.5rem 1rem;
+}
+
+.newProjectButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.75em 1.25em;
+  border: none;
+  border-radius: 0.5em;
+  background: $secondary;
+  color: $light;
+  font-weight: bold;
+  cursor: pointer;
+  transition: background 0.2s ease-in-out;
+
+  &:hover {
+    background: color.mix(#000, $secondary, 10%);
+  }
+}
+
+/* --- Inline project-type chips -------------------------------------------- */
+
+.typeChips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+  padding-block: 0.5em;
+}
+
+.typeChip {
+  border: 1px solid var(--border-color);
+  background: var(--bg-primary);
+  color: var(--text-muted);
+  border-radius: 1em;
+  padding: 0.3em 0.75em;
+  font-size: 0.8rem;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+
+  &:hover {
+    border-color: $accent;
+  }
+}
+
+.typeChipActive {
+  background: $accent;
+  border-color: $accent;
+  color: #fff;
+}
+
+/* --- Archived section ----------------------------------------------------- */
+
+.archivedSection {
+  margin-top: 2rem;
+  border-top: 1px solid var(--border-color);
+  padding-top: 1rem;
+
+  & > summary {
+    cursor: pointer;
+    font-weight: bold;
+    color: var(--text-secondary);
+    padding-block: 0.5rem;
+  }
+}
+
+/* --- New Project modal ---------------------------------------------------- */
+
+.modalOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: grid;
+  place-items: center;
+  background: rgba(0, 0, 0, 0.55);
+  padding: 1rem;
+}
+
+.modal {
+  width: 100%;
+  max-width: 420px;
+  background: var(--bg-card);
+  color: var(--text-primary);
+  border: 1px solid var(--border-color);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.modalTitle {
+  font-size: 1.3rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  border: none;
+  padding: 0;
+  margin: 0;
+
+  & > span {
+    font-size: 0.9rem;
+    font-weight: bold;
+    color: var(--text-secondary);
+  }
+
+  & > input {
+    padding: 0.6em 0.75em;
+    border: 1px solid var(--border-color);
+    border-radius: 0.5em;
+    background: var(--bg-primary);
+    color: var(--text-primary);
+  }
+}
+
+.modalError {
+  color: #e5484d;
+  font-size: 0.9rem;
+}
+
+.modalActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.modalCancel,
+.modalConfirm {
+  padding: 0.6em 1.25em;
+  border: none;
+  border-radius: 0.5em;
+  font-weight: bold;
+  cursor: pointer;
+
+  &:disabled {
+    opacity: 0.6;
+    cursor: default;
+  }
+}
+
+.modalCancel {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.modalConfirm {
+  background: $secondary;
+  color: $light;
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -55,7 +55,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
   const { data: config } = await getSiteConfig();
 
   const dynamicProjectPages = json.data.projects
-    .filter(({ slug }) => projectFlags(config, slug).visible)
+    .filter(({ slug }) => {
+      const flags = projectFlags(config, slug);
+      return flags.visible && !flags.archived;
+    })
     .map(({ slug }) => ({
       url: `${baseUrl}/projects/${slug}`,
       lastModified: currentDate,

--- a/src/components/RichTextEditor/AssetPicker.tsx
+++ b/src/components/RichTextEditor/AssetPicker.tsx
@@ -12,15 +12,17 @@ import styles from "./RichTextEditor.module.scss";
 type Props = {
   onSelect: (asset: MediaAsset) => void;
   onClose: () => void;
+  /** Dialog heading; defaults to the rich-text "Insert image" context. */
+  title?: string;
 };
 
 /**
- * Inline image picker for the rich-text editor. Loads assets through the same
- * Media Library data layer (via the `listMediaAssets` action), narrows to images
- * (the only thing insertable into rich text), and lets the admin search + pick
- * one without leaving the editor.
+ * Inline image picker. Loads assets through the same Media Library data layer
+ * (via the `listMediaAssets` action), narrows to images, and lets the admin
+ * search + pick one without leaving the page. Used by the rich-text editor and
+ * the project image control.
  */
-export default function AssetPicker({ onSelect, onClose }: Props) {
+export default function AssetPicker({ onSelect, onClose, title = "Insert image" }: Props) {
   const [assets, setAssets] = useState<MediaAsset[] | null>(null);
   const [error, setError] = useState("");
   const [query, setQuery] = useState("");
@@ -63,14 +65,14 @@ export default function AssetPicker({ onSelect, onClose }: Props) {
       className={styles.pickerOverlay}
       role="dialog"
       aria-modal="true"
-      aria-label="Insert image"
+      aria-label={title}
       onMouseDown={(e) => {
         if (e.target === e.currentTarget) onClose();
       }}
     >
       <div className={styles.pickerModal}>
         <div className={styles.pickerHead}>
-          <h2 className={styles.pickerTitle}>Insert image</h2>
+          <h2 className={styles.pickerTitle}>{title}</h2>
           <div className={styles.pickerHeadActions}>
             {/* Reuse the Media Library's crop & upload widget — a freshly
                 uploaded asset is inserted straight into the editor. */}

--- a/src/components/RichTextEditor/RichTextEditor.module.scss
+++ b/src/components/RichTextEditor/RichTextEditor.module.scss
@@ -252,7 +252,9 @@
 .pickerOverlay {
   position: fixed;
   inset: 0;
-  z-index: 1000;
+  // Above the admin modals (z 1100) so the picker can be opened from within the
+  // New Project dialog to choose its image.
+  z-index: 1200;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/src/lib/siteConfig.ts
+++ b/src/lib/siteConfig.ts
@@ -4,23 +4,31 @@
 // This module is intentionally pure (no server-only imports) so it can be shared
 // by client components. The CMS read lives in `getSiteConfig.ts`.
 
-export type ProjectFlags = { visible: boolean; featured: boolean };
+export type ProjectFlags = { visible: boolean; featured: boolean; archived: boolean };
+
+/** Per-card admin flags. `hidden` pulls a card from the public homepage but keeps
+ *  it recoverable from the admin "Hidden cards" area (archive, not delete). */
+export type PortfolioCardFlags = { hidden: boolean };
 
 export type SiteConfigData = {
-  projectOrder: string[];                      // slugs, in display order
-  featuredOrder: string[];                     // slugs, order of the featured section
-  projects: Record<string, ProjectFlags>;      // per-slug flags
+  projectOrder: string[];                          // slugs, in display order
+  featuredOrder: string[];                         // slugs, order of the featured section
+  projects: Record<string, ProjectFlags>;          // per-slug flags
+  portfolioCardOrder: string[];                    // card ids, in display order
+  portfolioCards: Record<string, PortfolioCardFlags>; // per-card-id flags
   homepage: {
     showPortfolioCards: boolean;
     showFeaturedProjects: boolean;
   };
-  site: Record<string, any>;                   // reserved for future settings
+  site: Record<string, any>;                       // reserved for future settings
 };
 
 export const DEFAULT_CONFIG: SiteConfigData = {
   projectOrder: [],
   featuredOrder: [],
   projects: {},
+  portfolioCardOrder: [],
+  portfolioCards: {},
   homepage: {
     showPortfolioCards: true,
     showFeaturedProjects: true
@@ -35,27 +43,38 @@ export function normalizeConfig(data: Partial<SiteConfigData> | null | undefined
     ...(data || {}),
     homepage: { ...DEFAULT_CONFIG.homepage, ...(data?.homepage || {}) },
     projects: { ...(data?.projects || {}) },
+    portfolioCards: { ...(data?.portfolioCards || {}) },
     site: { ...(data?.site || {}) }
   };
 }
 
 export function projectFlags(config: SiteConfigData, slug: string): ProjectFlags {
-  return config.projects[slug] || { visible: true, featured: false };
+  return { visible: true, featured: false, archived: false, ...config.projects[slug] };
 }
 
-/** Stable sort by an explicit list of slugs; unlisted items keep order, appended. */
-export function orderBySlugs<T extends { slug: string }>(projects: T[], order: string[]): T[] {
-  const rank = new Map(order.map((slug, i) => [slug, i]));
-  return [...projects].sort((a, b) => {
-    const ra = rank.has(a.slug) ? rank.get(a.slug)! : Infinity;
-    const rb = rank.has(b.slug) ? rank.get(b.slug)! : Infinity;
+export function cardFlags(config: SiteConfigData, id: string): PortfolioCardFlags {
+  return { hidden: false, ...config.portfolioCards[id] };
+}
+
+/** Stable sort by an explicit list of keys; unlisted items keep order, appended. */
+export function orderByKeys<T>(items: T[], order: string[], getKey: (item: T) => string): T[] {
+  const rank = new Map(order.map((key, i) => [key, i]));
+  return [...items].sort((a, b) => {
+    const ra = rank.has(getKey(a)) ? rank.get(getKey(a))! : Infinity;
+    const rb = rank.has(getKey(b)) ? rank.get(getKey(b))! : Infinity;
     return ra - rb;
   });
 }
 
+/** Stable sort by an explicit list of slugs; unlisted items keep order, appended. */
+export function orderBySlugs<T extends { slug: string }>(projects: T[], order: string[]): T[] {
+  return orderByKeys(projects, order, (p) => p.slug);
+}
+
 /**
  * Order projects by config.projectOrder (unlisted slugs keep CMS order, appended),
- * then optionally drop non-visible ones. Admins pass includeHidden to see all.
+ * then optionally drop hidden/archived ones. Admins pass includeHidden to see all
+ * (archived included) so the UI can group and dim them.
  */
 export function applyConfigToProjects<T extends { slug: string }>(
   projects: T[],
@@ -68,10 +87,13 @@ export function applyConfigToProjects<T extends { slug: string }>(
     return ordered;
   }
 
-  return ordered.filter((p) => projectFlags(config, p.slug).visible);
+  return ordered.filter((p) => {
+    const flags = projectFlags(config, p.slug);
+    return flags.visible && !flags.archived;
+  });
 }
 
-/** Visible + featured projects, ordered by config.featuredOrder. */
+/** Visible + featured (non-archived) projects, ordered by config.featuredOrder. */
 export function featuredProjects<T extends { slug: string }>(
   projects: T[],
   config: SiteConfigData
@@ -80,4 +102,22 @@ export function featuredProjects<T extends { slug: string }>(
     (p) => projectFlags(config, p.slug).featured
   );
   return orderBySlugs(visibleFeatured, config.featuredOrder);
+}
+
+/**
+ * Order portfolio cards by config.portfolioCardOrder (unlisted ids keep CMS order,
+ * appended), then optionally drop hidden ones. Admins pass includeHidden to see all.
+ */
+export function applyConfigToCards<T extends { id: string }>(
+  cards: T[],
+  config: SiteConfigData,
+  includeHidden = false
+): T[] {
+  const ordered = orderByKeys(cards, config.portfolioCardOrder, (c) => c.id);
+
+  if (includeHidden) {
+    return ordered;
+  }
+
+  return ordered.filter((c) => !cardFlags(config, c.id).hidden);
 }


### PR DESCRIPTION
This pull request introduces significant improvements to the admin management and editing experience for portfolio cards and projects, along with enhancements to the layout and styling of the portfolio section. The main changes include new admin-only controls and overlays for portfolio card management, expanded editable fields, new GraphQL mutations for portfolio card CRUD operations, and several UI/UX improvements for both project and portfolio management.

**Admin features and CRUD operations for portfolio cards:**

* Added admin-only overlays and controls to portfolio cards, including drag handles, edit, delete, and visibility toggles, as well as a modal for editing card details. New SCSS classes were introduced to support these features, such as `.adminCard`, `.adminOverlay`, `.addCardButton`, and modal-related styles.
* Expanded the set of editable fields for `PortfolioCard` and `Project` models, allowing admins to edit additional properties like `link`, `fontAwesomeIcon`, and `projectType`.
* Implemented full CRUD (create, update, delete) operations for portfolio cards in `contentActions.ts`, including new GraphQL mutations and appropriate authorization checks.

**Project management and editing improvements:**

* Enhanced the `Projects` admin interface with new controls: admins can now add, remove, and edit tags inline (`TagEditor`), change project images, toggle project types, and archive/restore projects. Additional FontAwesome icons were imported for these actions. [[1]](diffhunk://#diff-7292d48206e1b4dc03a126a183e44fa45549570ccb8ec27e7a044441faafeb32L9-R122) [[2]](diffhunk://#diff-7292d48206e1b4dc03a126a183e44fa45549570ccb8ec27e7a044441faafeb32R149-R156) [[3]](diffhunk://#diff-7292d48206e1b4dc03a126a183e44fa45549570ccb8ec27e7a044441faafeb32R173-R181) [[4]](diffhunk://#diff-7292d48206e1b4dc03a126a183e44fa45549570ccb8ec27e7a044441faafeb32L80-R216) [[5]](diffhunk://#diff-7292d48206e1b4dc03a126a183e44fa45549570ccb8ec27e7a044441faafeb32R227-R244)

**Portfolio layout and styling updates:**

* Switched the `.quickLinks` container from CSS grid to flex layout for better card centering, especially on partially filled rows, and adjusted responsive spacing and sizing.
* Updated portfolio card sizing rules for consistency across breakpoints, ensuring cards are always 300px wide except on mobile, where they become fluid. [[1]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L67-R73) [[2]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51R92)

**Homepage logic adjustments:**

* Modified the homepage to show portfolio cards to admins regardless of the `showPortfolioCards` config flag, and passed the full `config` object to the `Portfolio` component for more flexible rendering.