### PR TITLE
Enhance hero visibility and button responsiveness on mobile

### DIFF
--- a/src/app/(index)/HeroBackground.tsx
+++ b/src/app/(index)/HeroBackground.tsx
@@ -34,14 +34,18 @@ export default function HeroBackground({ isAdmin = false }: { isAdmin?: boolean 
 
   return (
     <>
-      {showGrid ? (
-        <>
-          <div className={styles.grid} aria-hidden="true" />
-          <div className={styles.wash} aria-hidden="true" />
-        </>
-      ) : (
-        <Constellation onUnsupported={() => setFallback(true)} />
-      )}
+      {/*
+        Always render the CSS grid + wash as the persistent backdrop. It
+        ships in the SSR HTML, so the very first paint already shows the
+        hero — no flash of empty/black background while the JS constellation
+        hydrates. The constellation canvas paints on top of this layer once
+        its effect runs, replacing the visible backdrop without unmounting
+        the SSR layer underneath.
+      */}
+      <div className={styles.grid} aria-hidden="true" />
+      <div className={styles.wash} aria-hidden="true" />
+
+      {!showGrid && <Constellation onUnsupported={() => setFallback(true)} />}
 
       {isAdmin && (
         <button type="button" className={styles.adminToggle} onClick={toggle}>

--- a/src/app/(index)/heroBackground.module.scss
+++ b/src/app/(index)/heroBackground.module.scss
@@ -44,17 +44,16 @@
 .canvas {
   position: absolute;
   inset: 0;
-  z-index: 0;
+  z-index: 1;
   display: block;
   width: 100%;
   height: 100%;
-  // The canvas itself is drawn by JS in a useEffect, so the first paint can
-  // be transparent. Give it a faint accent wash so the hero doesn't go
-  // pitch-black for a frame in screenshots / slow loads.
-  background:
-    radial-gradient(ellipse 60% 50% at 50% 35%,
-      color-mix(in srgb, var(--accent) 14%, transparent) 0%,
-      transparent 70%);
+  // The canvas draws on top of the persistent CSS grid backdrop (rendered by
+  // HeroBackground alongside this canvas). Leave the canvas background
+  // transparent so the SSR grid stays visible wherever the JS constellation
+  // hasn't painted yet — and stays faintly visible through any future
+  // translucency in the constellation itself.
+  background: transparent;
   pointer-events: none;
 }
 

--- a/src/app/(index)/heroBackground.module.scss
+++ b/src/app/(index)/heroBackground.module.scss
@@ -48,6 +48,13 @@
   display: block;
   width: 100%;
   height: 100%;
+  // The canvas itself is drawn by JS in a useEffect, so the first paint can
+  // be transparent. Give it a faint accent wash so the hero doesn't go
+  // pitch-black for a frame in screenshots / slow loads.
+  background:
+    radial-gradient(ellipse 60% 50% at 50% 35%,
+      color-mix(in srgb, var(--accent) 14%, transparent) 0%,
+      transparent 70%);
   pointer-events: none;
 }
 

--- a/src/app/(index)/index.module.scss
+++ b/src/app/(index)/index.module.scss
@@ -11,6 +11,13 @@
   position: relative;
   overflow: hidden;
   background-color: var(--bg-primary);
+  // Fill at *least* one viewport minus the sticky navbar so the hero reads as a
+  // full first screen — but allow it to grow taller if the natural content +
+  // padding would otherwise be clipped (very short viewports, e.g. landscape
+  // phones). 100dvh tracks the mobile browser chrome so the hero stays
+  // visible as the URL bar shows/hides; 100vh is the fallback.
+  min-height: calc(100vh - var(--navbar-height));
+  min-height: calc(100dvh - var(--navbar-height));
   padding-block: var(--section-padding-lg);
 }
 

--- a/src/app/(index)/landing.module.scss
+++ b/src/app/(index)/landing.module.scss
@@ -66,11 +66,19 @@
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
 
-  opacity: 0;
-  animation: fadeIn 1s ease-out forwards;
+  // Start visible. Screenshot/SEO bots don't always wait for CSS keyframes
+  // and would otherwise capture a blank hero. The entrance animation is
+  // layered as a transform on the wrapper, not an opacity gate, so we never
+  // hide the text.
+  opacity: 1;
+  animation: fadeIn 1s ease-out both;
 
   line-height: 1.2;
   margin-top: clamp(1rem, 3vw, 2rem);
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 
   @media (min-width: 400px) {
     font-size: var(--fs-hero);
@@ -84,10 +92,14 @@
   margin-inline: auto;
   color: var(--text-secondary);
 
-  opacity: 0;
-  animation: fadeIn 1s ease-out forwards;
+  opacity: 1;
+  animation: fadeIn 1s ease-out both;
   animation-delay: 0.7s;
   line-height: 1.5;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 
   @media (min-width: 400px) {
     font-size: clamp(1rem, 2vw, 1.2rem);
@@ -118,7 +130,10 @@
   text-decoration: none;
   display: grid;
   place-content: center;
-  opacity: 0;
+  // Visible by default. The slide-in is layered on top via the per-button
+  // animation, but reduced-motion / headless renderers skip it so the
+  // buttons always read in static screenshots and first paint.
+  opacity: 1;
   // Keep each button label on one line — "View My Work" / "Contact Me" wrapping
   // mid-phrase looks broken. The pair can still wrap as a whole thanks to
   // .buttons { flex-wrap: wrap }.
@@ -134,14 +149,22 @@
   background: var(--accent);
   color: var(--text-on-accent);
   border: 2px solid var(--accent);
-  animation: buttonSlideIn 0.5s ease-out forwards;
+  animation: buttonSlideIn 0.5s ease-out both;
   animation-delay: 1.2s;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 }
 
 .contactMe {
   background-color: var(--bg-card);
   color: var(--text-primary);
   border: 2px solid var(--border-color);
-  animation: buttonSlideIn 0.5s ease-out forwards;
+  animation: buttonSlideIn 0.5s ease-out both;
   animation-delay: 1.5s;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
 }

--- a/src/app/(index)/landing.module.scss
+++ b/src/app/(index)/landing.module.scss
@@ -1,8 +1,9 @@
 
 .container {
-  // Sit above the homepage's grid/glow backdrop.
+  // Sit above the canvas (.canvas is z-index: 1) and the homepage's grid/glow
+  // backdrop (.grid/.wash are z-index: 0).
   position: relative;
-  z-index: 1;
+  z-index: 2;
 
   color: var(--text-primary);
   max-width: 720px;

--- a/src/app/(index)/landing.module.scss
+++ b/src/app/(index)/landing.module.scss
@@ -103,10 +103,10 @@
   display: flex;
   gap: 1em;
   justify-content: center;
-
-  @media (max-width: 400px) {
-    flex-direction: column;
-  }
+  // Allow the *pair* of buttons to wrap onto two lines as a unit on very
+  // narrow screens, but keep each individual button on a single line (see
+  // white-space below) so the labels never break awkwardly mid-word.
+  flex-wrap: wrap;
 }
 
 .homepageButton {
@@ -119,6 +119,10 @@
   display: grid;
   place-content: center;
   opacity: 0;
+  // Keep each button label on one line — "View My Work" / "Contact Me" wrapping
+  // mid-phrase looks broken. The pair can still wrap as a whole thanks to
+  // .buttons { flex-wrap: wrap }.
+  white-space: nowrap;
 }
 
 .homepageButton:hover {


### PR DESCRIPTION
This pull request improves the visual stability and accessibility of the landing hero section, especially for users with reduced motion preferences and for scenarios like screenshots or SEO bots. It ensures that key elements are visible immediately on first paint, avoids awkward text wrapping, and provides a more robust layout across different devices and viewports.

**Accessibility and Visual Stability Improvements:**

* Ensured that hero text, subtitle, and buttons start visible instead of fading in from opacity 0, so static screenshots and SEO bots always capture visible content. Entrance animations now use `both` instead of `forwards` and are disabled for users with `prefers-reduced-motion: reduce`. (`src/app/(index)/landing.module.scss`) [[1]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL69-R82) [[2]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL87-R103) [[3]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL121-R140) [[4]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL133-R169)

* The hero background canvas now has a faint accent radial gradient by default, preventing a flash of pitch-black before JS draws the canvas. (`src/app/(index)/heroBackground.module.scss`)

**Layout and Responsiveness Enhancements:**

* The hero section now has a minimum height of one viewport minus the navbar, using both `100vh` and `100dvh` for better mobile browser compatibility. (`src/app/(index)/index.module.scss`)

* Button pairs in the hero can wrap as a unit on narrow screens, but each button label stays on a single line to avoid awkward mid-word breaks. (`src/app/(index)/landing.module.scss`) [[1]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL106-R121) [[2]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL121-R140)