### PR TITLE
Implement structured block system for project case-studies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,7 +31,7 @@ The site has a lightweight, **database-free admin editor**: log in with an env-v
 
 ## Content model (Hygraph)
 
-Simple scalar/list fields the admin may write inline are whitelisted in `EDITABLE_FIELDS` in `src/app/admin/contentActions.ts`: `Project`, `Description` (keyed by `location`), `PortfolioCard`. **Rich-text** fields are whitelisted separately in `EDITABLE_RICH_TEXT_FIELDS` (`Project.projectPageContent`, `RichTextWidget.content`) and edited via the `RichTextEditor` subsystem (see below). Relations are still **not** inline-editable.
+Simple scalar/list fields the admin may write inline are whitelisted in `EDITABLE_FIELDS` in `src/app/admin/contentActions.ts`: `Project`, `Description` (keyed by `location`), `PortfolioCard`. **Rich-text** fields are whitelisted separately in `EDITABLE_RICH_TEXT_FIELDS` (`RichTextWidget.content`) and edited via the `RichTextEditor` subsystem (see below). Relations are still **not** inline-editable.
 
 Presentation state lives in one **`SiteConfig`** entry (a single JSON `data` field), shaped by `SiteConfigData` in `siteConfig.ts`: `projectOrder`, `featuredOrder`, per-project `{ visible, featured }` flags, and `homepage` toggles. Defaults are applied so the site works before any config is saved.
 

--- a/src/app/admin/contentActions.ts
+++ b/src/app/admin/contentActions.ts
@@ -23,7 +23,6 @@ const EDITABLE_FIELDS: Record<string, string[]> = {
 // Rich-text (RichTextAST) fields the inline editor may write. Kept separate from
 // EDITABLE_FIELDS because the value is the AST JSON, not a simple scalar/list.
 const EDITABLE_RICH_TEXT_FIELDS: Record<string, string[]> = {
-  Project: ["projectPageContent"],
   RichTextWidget: ["content"]
 };
 
@@ -480,11 +479,8 @@ const CREATE_PROJECT_MUTATION = `
 type CreateProjectResult = { ok: true; id: string; slug: string } | { ok: false; error: string };
 
 // Placeholder text fields a fresh project gets so the (required) CMS fields are
-// satisfied; the admin overwrites them inline. An empty paragraph keeps the
-// rich-text body valid so the project page (which reads `projectPageContent.raw`)
-// renders right after the post-create redirect.
+// satisfied; the admin overwrites them inline.
 const NEW_PROJECT_DESCRIPTION = "Add a description for this project.";
-const EMPTY_RICH_TEXT = { children: [{ type: "paragraph", children: [{ text: "" }] }] };
 
 /**
  * Create a minimal project stub (title, slug, type) and publish it. Required text
@@ -522,7 +518,6 @@ export async function createProject(
         projectType,
         description: NEW_PROJECT_DESCRIPTION,
         projectPageDescription: NEW_PROJECT_DESCRIPTION,
-        projectPageContent: EMPTY_RICH_TEXT,
         image: { connect: { id: imageId } }
       }
     });

--- a/src/app/admin/contentActions.ts
+++ b/src/app/admin/contentActions.ts
@@ -5,6 +5,7 @@ import { cmsMutate, cmsUpload } from "@/lib/cms";
 import { getAssetById, getMediaAssets, type MediaAsset } from "@/lib/getAssets";
 import { getSiteConfig } from "@/lib/getSiteConfig";
 import { sanitizeRichTextAst } from "@/components/RichTextEditor/richTextAst";
+import { sanitizeProjectPage, type Block } from "@/components/ProjectBlocks/blocks";
 import { normalizeConfig, type SiteConfigData } from "@/lib/siteConfig";
 
 type ActionResult = { ok: true } | { ok: false; error: string };
@@ -310,6 +311,37 @@ export async function updateRichTextField(
   // No revalidatePath: consistent with the other writes — the client renders the
   // saved AST optimistically rather than refetching stale CDN data.
   return { ok: true };
+}
+
+type SaveBlocksResult = { ok: true; blocks: Block[] } | { ok: false; error: string };
+
+/**
+ * Persist a project's case-study block list to the `projectPage` JSON field, then
+ * publish. The incoming array is run through `sanitizeProjectPage` (defense in
+ * depth): invalid/unknown blocks are dropped, link/image URLs are checked, and
+ * rich-text sub-trees are sanitized — so a bypassed client can't store a broken
+ * layout or click-XSS into public content. Returns the cleaned blocks so the
+ * editor can adopt exactly what was stored (optimistic, no refetch).
+ */
+export async function updateProjectPage(
+  id: string,
+  blocks: unknown
+): Promise<SaveBlocksResult> {
+  const denied = await requireAuth();
+  if (denied) return denied;
+
+  const clean = sanitizeProjectPage(blocks);
+
+  try {
+    // Json field: store [] (not null) so the saved state is explicit.
+    await updateAndPublish("Project", id, { projectPage: clean });
+  } catch (e: any) {
+    return { ok: false, error: e?.message || "Failed to save page." };
+  }
+
+  // No revalidatePath: consistent with the other writes — the client renders the
+  // saved blocks optimistically rather than refetching stale CDN data.
+  return { ok: true, blocks: clean };
 }
 
 type ListAssetsResult = { assets: MediaAsset[] } | { error: string };

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -2,7 +2,10 @@ import { notFound } from 'next/navigation'
 import styles from "./Project.module.scss";
 import { Metadata } from "next";
 import Banner from "@/components/Banner";
-import RichTextField from "@/components/RichTextField";
+import RichTextWidget from "@/components/RichTextWidget";
+import ProjectBlocks from "@/components/ProjectBlocks/ProjectBlocks";
+import ProjectPageEditor from "@/components/ProjectBlocks/editor/ProjectPageEditor";
+import { sanitizeProjectPage } from "@/components/ProjectBlocks/blocks";
 import { cmsQuery } from "@/lib/cms";
 import { isAuthed } from "@/lib/auth";
 import { getSiteConfig } from "@/lib/getSiteConfig";
@@ -17,6 +20,7 @@ async function getProject(slug: string) {
             id
             title
             projectPageDescription
+            projectPage
             projectPageContent {
               raw
             }
@@ -71,6 +75,11 @@ export default async function Page({ params }) {
     notFound();
   }
 
+  // projectPage is the case-study block list (nullable — coerced to []). While a
+  // project hasn't been migrated to blocks, visitors fall back to the legacy
+  // projectPageContent rich text.
+  const blocks = sanitizeProjectPage(project.projectPage);
+
   return (
     <>
       <Banner
@@ -80,7 +89,17 @@ export default async function Page({ params }) {
       />
 
       <main className={styles.container} id="main-content" tabIndex={-1}>
-        <RichTextField model="Project" id={project.id} field="projectPageContent" raw={project.projectPageContent.raw} isAdmin={isAdmin} />
+        {isAdmin ? (
+          <ProjectPageEditor
+            projectId={project.id}
+            projectTitle={project.title}
+            initialBlocks={blocks}
+          />
+        ) : blocks.length > 0 ? (
+          <ProjectBlocks blocks={blocks} />
+        ) : (
+          <RichTextWidget content={project.projectPageContent?.raw} />
+        )}
       </main>
     </>
   );

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -2,7 +2,6 @@ import { notFound } from 'next/navigation'
 import styles from "./Project.module.scss";
 import { Metadata } from "next";
 import Banner from "@/components/Banner";
-import RichTextWidget from "@/components/RichTextWidget";
 import ProjectBlocks from "@/components/ProjectBlocks/ProjectBlocks";
 import ProjectPageEditor from "@/components/ProjectBlocks/editor/ProjectPageEditor";
 import { sanitizeProjectPage } from "@/components/ProjectBlocks/blocks";
@@ -21,9 +20,6 @@ async function getProject(slug: string) {
             title
             projectPageDescription
             projectPage
-            projectPageContent {
-              raw
-            }
           }
         }
       `,
@@ -75,9 +71,8 @@ export default async function Page({ params }) {
     notFound();
   }
 
-  // projectPage is the case-study block list (nullable — coerced to []). While a
-  // project hasn't been migrated to blocks, visitors fall back to the legacy
-  // projectPageContent rich text.
+  // projectPage is the case-study block list. It is null until populated in the
+  // CMS, so sanitizeProjectPage coerces a missing value to an empty list.
   const blocks = sanitizeProjectPage(project.projectPage);
 
   return (
@@ -95,10 +90,8 @@ export default async function Page({ params }) {
             projectTitle={project.title}
             initialBlocks={blocks}
           />
-        ) : blocks.length > 0 ? (
-          <ProjectBlocks blocks={blocks} />
         ) : (
-          <RichTextWidget content={project.projectPageContent?.raw} />
+          blocks.length > 0 && <ProjectBlocks blocks={blocks} />
         )}
       </main>
     </>

--- a/src/components/ProjectBlocks/Callout.tsx
+++ b/src/components/ProjectBlocks/Callout.tsx
@@ -1,0 +1,53 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faQuoteLeft,
+  faCircleInfo,
+  faCircleCheck,
+  faTriangleExclamation
+} from "@fortawesome/free-solid-svg-icons";
+import type { IconDefinition } from "@fortawesome/fontawesome-svg-core";
+import type { CalloutBlock, CalloutVariant } from "./blocks";
+import styles from "./ProjectBlocks.module.scss";
+
+// Each variant pairs an icon with a visible label so the meaning is never
+// conveyed by colour alone (WCAG 1.4.1).
+const VARIANTS: Record<CalloutVariant, { icon: IconDefinition; label: string; cls: string }> = {
+  quote: { icon: faQuoteLeft, label: "Quote", cls: styles.calloutQuote },
+  info: { icon: faCircleInfo, label: "Note", cls: styles.calloutInfo },
+  success: { icon: faCircleCheck, label: "Success", cls: styles.calloutSuccess },
+  warning: { icon: faTriangleExclamation, label: "Warning", cls: styles.calloutWarning }
+};
+
+/**
+ * A pull quote or highlighted note. Quotes render as a semantic
+ * <blockquote><cite>; status variants get an icon + visible label.
+ */
+export default function Callout({ block }: { block: CalloutBlock }) {
+  const variant = VARIANTS[block.variant] ?? VARIANTS.info;
+
+  if (block.variant === "quote") {
+    return (
+      <section className={`${styles.block} ${styles.measure}`}>
+        <blockquote className={variant.cls}>
+          <span className={styles.quoteMark} aria-hidden>
+            &ldquo;
+          </span>
+          <p className={styles.calloutText}>{block.text}</p>
+          {block.attribution && <cite className={styles.calloutCite}>{block.attribution}</cite>}
+        </blockquote>
+      </section>
+    );
+  }
+
+  return (
+    <section className={`${styles.block} ${styles.measure}`}>
+      <div className={`${styles.callout} ${variant.cls}`} role="note">
+        <FontAwesomeIcon icon={variant.icon} className={styles.calloutIcon} aria-hidden />
+        <div>
+          <p className={styles.calloutLabel}>{variant.label}</p>
+          <p className={styles.calloutText}>{block.text}</p>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectBlocks/Cta.tsx
+++ b/src/components/ProjectBlocks/Cta.tsx
@@ -1,0 +1,38 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowRight, faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import type { CtaBlock } from "./blocks";
+import styles from "./ProjectBlocks.module.scss";
+
+/**
+ * Closing call-to-action: a short prompt and a styled button, in a tinted panel
+ * so it reads as a deliberate end-cap rather than an orphaned link. Stacks on
+ * mobile. External links open in a new tab and get the appropriate icon.
+ */
+export default function Cta({ block }: { block: CtaBlock }) {
+  const external = /^https?:\/\//i.test(block.href);
+
+  return (
+    <section className={`${styles.block} ${styles.wide}`}>
+      <div className={styles.cta}>
+        {(block.heading || block.text) && (
+          <div className={styles.ctaBody}>
+            {block.heading && <p className={styles.ctaHeading}>{block.heading}</p>}
+            {block.text && <p className={styles.ctaText}>{block.text}</p>}
+          </div>
+        )}
+        <a
+          href={block.href}
+          className={styles.ctaButton}
+          {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+        >
+          {block.label}
+          <FontAwesomeIcon
+            icon={external ? faArrowUpRightFromSquare : faArrowRight}
+            className={styles.ctaButtonIcon}
+            aria-hidden
+          />
+        </a>
+      </div>
+    </section>
+  );
+}

--- a/src/components/ProjectBlocks/FeatureGrid.tsx
+++ b/src/components/ProjectBlocks/FeatureGrid.tsx
@@ -1,0 +1,31 @@
+import type { FeatureGridBlock } from "./blocks";
+import styles from "./ProjectBlocks.module.scss";
+
+/**
+ * Features / capabilities as a responsive card grid — the styled alternative to a
+ * plain bullet list, so short lists fill horizontal space instead of stacking into
+ * a thin sliver. Hierarchy comes from a top accent hairline and type weight rather
+ * than icons or index numerals. When no item has a description the grid uses compact
+ * tiles (more columns); when any do, it uses larger cards. Semantic <ol> + <h3> per
+ * item keeps it readable to assistive tech.
+ */
+export default function FeatureGrid({ block }: { block: FeatureGridBlock }) {
+  const hasDescriptions = block.items.some((i) => i.description);
+
+  return (
+    <section className={`${styles.block} ${styles.wide}`}>
+      {block.heading && <h2 className={styles.blockHeading}>{block.heading}</h2>}
+      <ol className={`${styles.featureGrid} ${hasDescriptions ? styles.featureCards : styles.featureTiles}`}>
+        {block.items.map((item, i) => (
+          <li key={i} className={styles.featureItem}>
+            <span className={styles.featureAccent} aria-hidden />
+            <div className={styles.featureBody}>
+              <h3 className={styles.featureTitle}>{item.title}</h3>
+              {item.description && <p className={styles.featureDesc}>{item.description}</p>}
+            </div>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/src/components/ProjectBlocks/Gallery.tsx
+++ b/src/components/ProjectBlocks/Gallery.tsx
@@ -1,0 +1,129 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faXmark, faChevronLeft, faChevronRight } from "@fortawesome/free-solid-svg-icons";
+import Modal from "@/components/Modal";
+import type { GalleryBlock } from "./blocks";
+import styles from "./ProjectBlocks.module.scss";
+
+/**
+ * Screenshot/diagram gallery with a lightbox. The grid auto-reflows (more columns
+ * on wider viewports, one on mobile). The lightbox reuses the shared Modal, so it
+ * gets focus-trap, Escape-to-close and focus restoration for free; arrow keys and
+ * on-screen controls page between images.
+ */
+export default function Gallery({ block }: { block: GalleryBlock }) {
+  const [openIndex, setOpenIndex] = useState<number | null>(null);
+  const count = block.images.length;
+  const wide = block.layout === "wide";
+
+  function go(delta: number) {
+    setOpenIndex((i) => (i === null ? i : (i + delta + count) % count));
+  }
+
+  // Page with the arrow keys whenever the lightbox is open, regardless of which
+  // element inside the modal currently holds focus.
+  useEffect(() => {
+    if (openIndex === null || count < 2) return;
+    function onKey(e: KeyboardEvent) {
+      if (e.key === "ArrowRight") {
+        e.preventDefault();
+        go(1);
+      } else if (e.key === "ArrowLeft") {
+        e.preventDefault();
+        go(-1);
+      }
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [openIndex, count]);
+
+  const active = openIndex === null ? null : block.images[openIndex];
+
+  return (
+    <section className={`${styles.block} ${styles.wide}`}>
+      {block.heading && <h2 className={styles.blockHeading}>{block.heading}</h2>}
+
+      <ul className={`${styles.galleryGrid} ${wide ? styles.galleryWide : ""}`}>
+        {block.images.map((img, i) => (
+          <li key={i} className={styles.galleryItem}>
+            <figure className={styles.galleryFigure}>
+              <button
+                type="button"
+                className={styles.galleryThumbBtn}
+                onClick={() => setOpenIndex(i)}
+                aria-label={`Open image ${i + 1} of ${count}${img.alt ? `: ${img.alt}` : ""}`}
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={img.src}
+                  alt={img.alt ?? ""}
+                  width={img.width}
+                  height={img.height}
+                  loading="lazy"
+                />
+              </button>
+              {img.caption && (
+                <figcaption className={styles.galleryCaption}>{img.caption}</figcaption>
+              )}
+            </figure>
+          </li>
+        ))}
+      </ul>
+
+      {active && (
+        <Modal
+          onClose={() => setOpenIndex(null)}
+          label={active.alt || "Image preview"}
+          overlayClassName={styles.lightboxOverlay}
+        >
+          <div className={styles.lightboxBox}>
+            {count > 1 && (
+              <button
+                type="button"
+                className={`${styles.lightboxNav} ${styles.lightboxPrev}`}
+                onClick={() => go(-1)}
+                aria-label="Previous image"
+              >
+                <FontAwesomeIcon icon={faChevronLeft} />
+              </button>
+            )}
+
+            <figure className={styles.lightboxFigure}>
+              <div className={styles.lightboxHeader}>
+                <span className={styles.lightboxCounter}>
+                  {openIndex! + 1} / {count}
+                </span>
+                <button
+                  type="button"
+                  className={styles.lightboxClose}
+                  onClick={() => setOpenIndex(null)}
+                  aria-label="Close image preview"
+                >
+                  <FontAwesomeIcon icon={faXmark} />
+                </button>
+              </div>
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={active.src} alt={active.alt ?? ""} />
+              {active.caption && (
+                <figcaption className={styles.lightboxCaption}>{active.caption}</figcaption>
+              )}
+            </figure>
+
+            {count > 1 && (
+              <button
+                type="button"
+                className={`${styles.lightboxNav} ${styles.lightboxNext}`}
+                onClick={() => go(1)}
+                aria-label="Next image"
+              >
+                <FontAwesomeIcon icon={faChevronRight} />
+              </button>
+            )}
+          </div>
+        </Modal>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProjectBlocks/Hero.tsx
+++ b/src/components/ProjectBlocks/Hero.tsx
@@ -1,0 +1,86 @@
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faArrowRight, faArrowUpRightFromSquare } from "@fortawesome/free-solid-svg-icons";
+import type { HeroBlock } from "./blocks";
+import styles from "./ProjectBlocks.module.scss";
+
+/** Split "Label: Value" into its parts; falls back to the whole string as value. */
+function splitFact(fact: string): { label?: string; value: string } {
+  const i = fact.indexOf(":");
+  if (i === -1) return { value: fact.trim() };
+  return { label: fact.slice(0, i).trim(), value: fact.slice(i + 1).trim() };
+}
+
+/**
+ * Project hero. Renders below the page Banner (which owns the single <h1>), so the
+ * headline is an <h2>. Bold display headline, a monospace eyebrow, a "spec strip"
+ * of key facts, and an optional framed lead image. Stacks on smaller screens.
+ */
+export default function Hero({ block }: { block: HeroBlock }) {
+  const hasImage = !!block.image?.src;
+
+  return (
+    <section className={`${styles.block} ${styles.hero} ${hasImage ? styles.heroSplit : ""}`}>
+      <div className={styles.heroBody}>
+        {block.eyebrow && (
+          <p className={styles.heroEyebrow}>
+            <span className={styles.heroEyebrowTick} aria-hidden />
+            {block.eyebrow}
+          </p>
+        )}
+        <h2 className={styles.heroHeadline}>{block.headline}</h2>
+        {block.summary && <p className={styles.heroSummary}>{block.summary}</p>}
+
+        {block.roleItems && block.roleItems.length > 0 && (
+          <dl className={styles.heroFacts}>
+            {block.roleItems.map((item, i) => {
+              const { label, value } = splitFact(item);
+              return (
+                <div key={i} className={styles.heroFact}>
+                  {label && <dt className={styles.heroFactLabel}>{label}</dt>}
+                  <dd className={styles.heroFactValue}>{value}</dd>
+                </div>
+              );
+            })}
+          </dl>
+        )}
+
+        {block.actions && block.actions.length > 0 && (
+          <div className={styles.heroActions}>
+            {block.actions.map((action, i) => {
+              const external = /^https?:\/\//i.test(action.href);
+              const primary = i === 0;
+              return (
+                <a
+                  key={i}
+                  href={action.href}
+                  className={primary ? styles.heroActionPrimary : styles.heroActionSecondary}
+                  {...(external ? { target: "_blank", rel: "noopener noreferrer" } : {})}
+                >
+                  {action.label}
+                  <FontAwesomeIcon
+                    icon={external ? faArrowUpRightFromSquare : faArrowRight}
+                    className={styles.heroActionIcon}
+                    aria-hidden
+                  />
+                </a>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      {block.image?.src && (
+        <div className={styles.heroMedia}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={block.image.src}
+            alt={block.image.alt ?? ""}
+            width={block.image.width}
+            height={block.image.height}
+            loading="eager"
+          />
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/ProjectBlocks/ProjectBlocks.module.scss
+++ b/src/components/ProjectBlocks/ProjectBlocks.module.scss
@@ -1,0 +1,841 @@
+// Project case-study blocks — an "engineering spec-sheet / editorial" system:
+// monospace technical labels, emerald accent ticks, hairline rules, confident
+// display type and numerals. All colours come from the theme tokens, so every
+// block works in light + dark. The frontend owns layout; multi-column areas
+// auto-reflow on smaller screens.
+
+$mono: ui-monospace, "Cascadia Code", "JetBrains Mono", "Source Code Pro", Menlo, Consolas, monospace;
+
+.blocks {
+  width: 100%;
+  max-width: 1080px;
+  margin-inline: auto;
+  display: flex;
+  flex-direction: column;
+  gap: clamp(3rem, 6vw, 5rem);
+}
+
+// Reading measure for prose-width sections; .wide for bands (stats, tech, media).
+.measure {
+  width: 100%;
+  max-width: 720px;
+  margin-inline: auto;
+}
+
+.wide {
+  width: 100%;
+  max-width: 960px;
+  margin-inline: auto;
+}
+
+.block {
+  width: 100%;
+}
+
+// Shared section heading — identical to the rich-text <h2> so prose and blocks
+// read as one continuous page: a short accent rule, then a confident display line.
+.blockHeading {
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(1.5rem, 3vw, 2rem);
+  line-height: 1.2;
+  letter-spacing: -0.02em;
+  color: var(--text-primary);
+  margin: 0 0 1.75rem;
+
+  &::before {
+    content: "";
+    display: block;
+    width: 2.25rem;
+    height: 3px;
+    margin-bottom: 0.9rem;
+    border-radius: 2px;
+    background: linear-gradient(90deg, var(--accent), transparent);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hero
+// ---------------------------------------------------------------------------
+
+.hero {
+  display: grid;
+  gap: clamp(1.75rem, 4vw, 3rem);
+  align-items: center;
+}
+
+.heroSplit {
+  @media (min-width: 820px) {
+    grid-template-columns: 1fr 0.82fr;
+  }
+}
+
+.heroBody {
+  min-width: 0;
+}
+
+.heroEyebrow {
+  display: flex;
+  align-items: center;
+  font-family: $mono;
+  text-transform: uppercase;
+  letter-spacing: 0.16em;
+  font-size: 0.78rem;
+  color: var(--accent-text);
+  margin: 0 0 1.25rem;
+}
+
+.heroEyebrowTick {
+  width: 1.75rem;
+  height: 2px;
+  margin-right: 0.85rem;
+  border-radius: 2px;
+  background-color: var(--accent);
+}
+
+.heroHeadline {
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(2.4rem, 6vw, 3.6rem);
+  line-height: 1.04;
+  letter-spacing: -0.03em;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.heroSummary {
+  font-size: 1.15rem;
+  line-height: 1.6;
+  color: var(--text-secondary);
+  max-width: 46ch;
+  margin: 1.25rem 0 0;
+}
+
+.heroFacts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem 1.75rem;
+  margin: 2rem 0 0;
+}
+
+.heroFact {
+  padding-left: 0.85rem;
+  border-left: 2px solid var(--accent);
+}
+
+.heroFactLabel {
+  font-family: $mono;
+  font-size: 0.68rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-muted);
+}
+
+.heroFactValue {
+  margin: 0.2rem 0 0;
+  font-size: 0.98rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.heroActions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.85rem;
+  margin-top: 2.25rem;
+}
+
+.heroActionPrimary,
+.heroActionSecondary {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  min-height: 44px;
+  padding: 0.65rem 1.35rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  text-decoration: none;
+  transition: transform var(--transition-fast, 0.2s ease), box-shadow var(--transition-fast, 0.2s ease),
+    background-color var(--transition-fast, 0.2s ease);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+
+    .heroActionIcon {
+      transform: translateX(3px);
+    }
+  }
+}
+
+.heroActionPrimary {
+  background-color: var(--accent);
+  color: var(--text-on-accent);
+}
+
+.heroActionSecondary {
+  background-color: transparent;
+  color: var(--accent-text);
+  border: 1px solid var(--border-color);
+
+  &:hover {
+    background-color: var(--bg-secondary);
+    border-color: var(--accent);
+  }
+}
+
+.heroActionIcon {
+  font-size: 0.8em;
+  transition: transform var(--transition-fast, 0.2s ease);
+}
+
+.heroMedia {
+  position: relative;
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+
+  img {
+    display: block;
+    width: 100%;
+    height: auto;
+    aspect-ratio: 2 / 1;
+    object-fit: cover;
+  }
+
+  // Single bold accent: a solid bar along the bottom edge that grounds the
+  // image and ties it to the page's accent without framing it like a card.
+  &::after {
+    content: "";
+    position: absolute;
+    inset: auto 0 0 0;
+    height: 4px;
+    background-color: var(--accent);
+    z-index: 1;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Feature grid — styled alternative to a bullet list
+// ---------------------------------------------------------------------------
+
+.featureGrid {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.85rem;
+}
+
+.featureTiles {
+  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
+}
+
+.featureCards {
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.featureItem {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  padding: 1.15rem 1.2rem;
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: transform var(--transition-fast, 0.2s ease), border-color var(--transition-fast, 0.2s ease),
+    box-shadow var(--transition-fast, 0.2s ease);
+
+  &:hover {
+    border-color: var(--accent);
+    box-shadow: var(--shadow-sm);
+  }
+}
+
+// Top accent hairline carries the hierarchy in place of an icon/numeral —
+// a quiet, static marker rather than an animated one.
+.featureAccent {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 2.25rem;
+  height: 3px;
+  border-radius: 0 2px 2px 0;
+  background-color: var(--accent);
+}
+
+.featureBody {
+  min-width: 0;
+  margin-top: 0.55rem;
+}
+
+.featureTitle {
+  font-family: var(--font-display), sans-serif;
+  font-size: 1rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  line-height: 1.3;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.featureCards .featureTitle {
+  font-size: 1.1rem;
+}
+
+.featureDesc {
+  margin: 0.45rem 0 0;
+  font-size: 0.92rem;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+// ---------------------------------------------------------------------------
+// Stats — spec band
+// ---------------------------------------------------------------------------
+
+.statsRow {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 1.75rem 2.5rem;
+  margin: 0;
+}
+
+.statItem {
+  position: relative;
+  padding-top: 1.15rem;
+
+  &::before {
+    content: "";
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 2.5rem;
+    height: 3px;
+    border-radius: 2px;
+    background: linear-gradient(90deg, var(--accent), transparent);
+    transition: width var(--transition, 0.3s ease);
+  }
+
+  &:hover::before {
+    width: 100%;
+  }
+}
+
+.statValue {
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(2.4rem, 5vw, 3.4rem);
+  font-weight: 700;
+  line-height: 1;
+  letter-spacing: -0.02em;
+  color: var(--accent-text);
+  font-variant-numeric: tabular-nums;
+}
+
+.statLabel {
+  margin: 0.7rem 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.statLabelText {
+  font-size: 0.98rem;
+  font-weight: 500;
+  line-height: 1.3;
+  color: var(--text-primary);
+}
+
+.statCaption {
+  font-family: $mono;
+  font-size: 0.72rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+// ---------------------------------------------------------------------------
+// Tech stack — spec table (label column + wrapping chips per row)
+// ---------------------------------------------------------------------------
+
+.techTable {
+  margin: 0;
+  border-top: 1px solid var(--border-color);
+}
+
+.techRow {
+  display: grid;
+  grid-template-columns: minmax(120px, 200px) 1fr;
+  gap: 1.5rem 2rem;
+  align-items: baseline;
+  padding: 1.15rem 0;
+  border-bottom: 1px solid var(--border-color);
+
+  @media (max-width: 560px) {
+    grid-template-columns: 1fr;
+    gap: 0.65rem;
+  }
+}
+
+.techRowLabel {
+  font-family: $mono;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--accent-text);
+}
+
+.techChips {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  padding: 0;
+  margin: 0;
+}
+
+.techChip {
+  font-family: $mono;
+  font-size: 0.82rem;
+  color: var(--text-secondary);
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.35rem 0.7rem;
+  transition: color var(--transition-fast, 0.2s ease), border-color var(--transition-fast, 0.2s ease),
+    transform var(--transition-fast, 0.2s ease);
+
+  &:hover {
+    color: var(--accent-text);
+    border-color: var(--accent);
+    transform: translateY(-1px);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Callout / pull quote
+// ---------------------------------------------------------------------------
+
+.calloutQuote {
+  position: relative;
+  margin: 0;
+  padding: 0.25rem 0 0.25rem 3.75rem;
+}
+
+.quoteMark {
+  position: absolute;
+  left: -0.25rem;
+  top: -0.85rem;
+  font-family: var(--font-display), serif;
+  font-size: 5rem;
+  line-height: 1;
+  color: var(--accent);
+  opacity: 0.5;
+}
+
+.calloutQuote .calloutText {
+  font-family: var(--font-display), sans-serif;
+  font-size: clamp(1.3rem, 2.8vw, 1.75rem);
+  line-height: 1.4;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.calloutCite {
+  display: block;
+  margin-top: 1rem;
+  font-family: $mono;
+  font-size: 0.78rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-style: normal;
+  color: var(--text-muted);
+
+  &::before {
+    content: "— ";
+  }
+}
+
+// Note variants (info / success / warning)
+.callout {
+  display: flex;
+  gap: 1rem;
+  padding: 1.1rem 1.35rem;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  border-left-width: 3px;
+  align-items: flex-start;
+}
+
+.calloutIcon {
+  flex-shrink: 0;
+  font-size: 1.1rem;
+  margin-top: 0.15rem;
+}
+
+.calloutLabel {
+  margin: 0 0 0.25rem;
+  font-family: $mono;
+  font-size: 0.74rem;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.callout .calloutText {
+  margin: 0;
+  color: var(--text-primary);
+  line-height: 1.6;
+}
+
+.calloutInfo {
+  background-color: var(--bg-secondary);
+  border-left-color: var(--accent-secondary);
+
+  .calloutIcon,
+  .calloutLabel {
+    color: var(--accent-secondary);
+  }
+}
+
+.calloutSuccess {
+  background-color: var(--success-bg);
+  border-color: var(--success-border);
+  border-left-color: var(--success-border);
+
+  .calloutIcon,
+  .calloutLabel {
+    color: var(--accent-text);
+  }
+
+  .calloutText {
+    color: #173d17;
+  }
+}
+
+.calloutWarning {
+  background-color: color-mix(in srgb, var(--accent-highlight) 16%, var(--bg-card));
+  border-left-color: var(--accent-highlight);
+
+  .calloutIcon,
+  .calloutLabel {
+    color: color-mix(in srgb, var(--accent-highlight) 75%, #000);
+  }
+}
+
+:global([data-theme="dark"]) .calloutSuccess .calloutText {
+  color: var(--text-primary);
+}
+
+// ---------------------------------------------------------------------------
+// Call to action
+// ---------------------------------------------------------------------------
+
+.cta {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem 2rem;
+  padding: clamp(1.5rem, 3vw, 2.25rem);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  background:
+    linear-gradient(
+      130deg,
+      color-mix(in srgb, var(--accent) 10%, var(--bg-card)),
+      var(--bg-card) 65%
+    );
+}
+
+.ctaBody {
+  min-width: 0;
+}
+
+.ctaHeading {
+  font-family: var(--font-display), sans-serif;
+  font-size: 1.3rem;
+  font-weight: 600;
+  letter-spacing: -0.015em;
+  color: var(--text-primary);
+  margin: 0;
+}
+
+.ctaText {
+  margin: 0.35rem 0 0;
+  color: var(--text-secondary);
+  line-height: 1.55;
+}
+
+.ctaButton {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.55rem;
+  flex-shrink: 0;
+  min-height: 44px;
+  padding: 0.7rem 1.5rem;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  text-decoration: none;
+  background-color: var(--accent);
+  color: var(--text-on-accent);
+  transition: transform var(--transition-fast, 0.2s ease), box-shadow var(--transition-fast, 0.2s ease);
+
+  &:hover {
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-md);
+
+    .ctaButtonIcon {
+      transform: translateX(3px);
+    }
+  }
+}
+
+.ctaButtonIcon {
+  font-size: 0.8em;
+  transition: transform var(--transition-fast, 0.2s ease);
+}
+
+// ---------------------------------------------------------------------------
+// Video
+// ---------------------------------------------------------------------------
+
+.videoFigure {
+  margin: 0;
+}
+
+.video {
+  width: 100%;
+  height: auto;
+  display: block;
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-md);
+  background-color: #000;
+}
+
+.videoCaption {
+  margin-top: 0.75rem;
+  font-family: $mono;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+}
+
+// ---------------------------------------------------------------------------
+// Gallery
+// ---------------------------------------------------------------------------
+
+.galleryGrid {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.galleryWide {
+  grid-template-columns: repeat(auto-fill, minmax(360px, 1fr));
+}
+
+.galleryItem {
+  min-width: 0;
+}
+
+.galleryFigure {
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.7rem;
+}
+
+// The button is the image frame: hover zoom is clipped here so it can never
+// bleed over the caption, and only this element is the modal trigger.
+.galleryThumbBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  padding: 0;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  background-color: var(--bg-secondary);
+  cursor: pointer;
+  line-height: 0;
+  transition: border-color var(--transition-fast, 0.2s ease),
+    box-shadow var(--transition-fast, 0.2s ease);
+
+  // Keep each image's natural orientation, but cap the largest dimension so tall
+  // portraits don't dominate — landscapes fill the width, portraits cap by height.
+  img {
+    max-width: 100%;
+    max-height: clamp(240px, 30vw, 340px);
+    width: auto;
+    height: auto;
+    display: block;
+    transition: transform var(--transition, 0.3s ease);
+  }
+
+  &:hover {
+    border-color: var(--accent);
+    box-shadow: var(--shadow-sm);
+
+    img {
+      transform: scale(1.05);
+    }
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+  }
+}
+
+// Sibling of the button — normal, selectable content.
+.galleryCaption {
+  font-family: $mono;
+  font-size: 0.76rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+  text-align: left;
+}
+
+// Lightbox (reuses Modal for focus-trap / Escape / focus restore)
+.lightboxOverlay {
+  position: fixed;
+  inset: 0;
+  z-index: 1100;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 4vw, 3rem);
+  background-color: var(--overlay-scrim);
+}
+
+.lightboxBox {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  max-width: min(1100px, 100%);
+  max-height: 100%;
+}
+
+.lightboxFigure {
+  position: relative;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1rem;
+  padding: clamp(0.85rem, 2vw, 1.25rem);
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+
+  img {
+    max-width: 100%;
+    max-height: 78vh;
+    width: auto;
+    height: auto;
+    display: block;
+    margin: 0 auto;
+    border-radius: var(--radius-sm);
+  }
+}
+
+.lightboxCaption {
+  text-align: center;
+  color: var(--text-secondary);
+  font-family: $mono;
+  font-size: 0.82rem;
+  line-height: 1.5;
+}
+
+.lightboxNav {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 44px;
+  min-height: 44px;
+  border-radius: 50%;
+  border: none;
+  cursor: pointer;
+  color: #fff;
+  background-color: rgba(15, 23, 42, 0.7);
+  font-size: 1.1rem;
+
+  &:hover {
+    background-color: rgba(15, 23, 42, 0.9);
+  }
+}
+
+// Header bar at the top of the panel — counter on the left, close on the right.
+.lightboxHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  width: 100%;
+  margin-bottom: -0.25rem;
+}
+
+.lightboxCounter {
+  font-family: $mono;
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+  font-variant-numeric: tabular-nums;
+}
+
+.lightboxClose {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  min-height: 36px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+  background-color: var(--bg-secondary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  font-size: 1rem;
+  transition: color var(--transition-fast, 0.2s ease),
+    border-color var(--transition-fast, 0.2s ease),
+    background-color var(--transition-fast, 0.2s ease);
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--accent);
+    background-color: var(--bg-card);
+  }
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .galleryThumbBtn:hover img,
+  .featureItem:hover,
+  .techChip:hover,
+  .heroActionPrimary:hover,
+  .heroActionSecondary:hover,
+  .heroActionPrimary:hover .heroActionIcon,
+  .heroActionSecondary:hover .heroActionIcon,
+  .ctaButton:hover,
+  .ctaButton:hover .ctaButtonIcon {
+    transform: none;
+  }
+
+  .statItem::before,
+  .featureAccent {
+    transition: none;
+  }
+}

--- a/src/components/ProjectBlocks/ProjectBlocks.tsx
+++ b/src/components/ProjectBlocks/ProjectBlocks.tsx
@@ -1,0 +1,52 @@
+import RichTextWidget from "@/components/RichTextWidget";
+import type { Block } from "./blocks";
+import Hero from "./Hero";
+import FeatureGrid from "./FeatureGrid";
+import Stats from "./Stats";
+import TechStack from "./TechStack";
+import Gallery from "./Gallery";
+import Video from "./Video";
+import Callout from "./Callout";
+import Cta from "./Cta";
+import styles from "./ProjectBlocks.module.scss";
+
+/**
+ * Visitor-facing renderer for a project's case-study blocks. Maps each block's
+ * `type` to its presentational component; the rich-text block reuses the existing
+ * RichTextWidget so prose looks identical to before. Server-rendered (the gallery
+ * lightbox is the only client island). Callers pass an already-sanitized list.
+ */
+export default function ProjectBlocks({ blocks }: { blocks: Block[] }) {
+  return (
+    <div className={styles.blocks}>
+      {blocks.map((block) => {
+        switch (block.type) {
+          case "hero":
+            return <Hero key={block.id} block={block} />;
+          case "richText":
+            return (
+              <section key={block.id} className={`${styles.block} ${styles.measure}`}>
+                <RichTextWidget content={block.content} variant="bare" />
+              </section>
+            );
+          case "featureGrid":
+            return <FeatureGrid key={block.id} block={block} />;
+          case "stats":
+            return <Stats key={block.id} block={block} />;
+          case "techStack":
+            return <TechStack key={block.id} block={block} />;
+          case "gallery":
+            return <Gallery key={block.id} block={block} />;
+          case "video":
+            return <Video key={block.id} block={block} />;
+          case "callout":
+            return <Callout key={block.id} block={block} />;
+          case "cta":
+            return <Cta key={block.id} block={block} />;
+          default:
+            return null;
+        }
+      })}
+    </div>
+  );
+}

--- a/src/components/ProjectBlocks/Stats.tsx
+++ b/src/components/ProjectBlocks/Stats.tsx
@@ -1,0 +1,26 @@
+import type { StatsBlock } from "./blocks";
+import styles from "./ProjectBlocks.module.scss";
+
+/**
+ * Impact metrics as a "spec band": oversized display numerals, each with an accent
+ * tick above and a monospace label below. Rendered as a <dl> so each value is tied
+ * to its label for screen readers. The band auto-fits and reflows to fewer columns.
+ */
+export default function Stats({ block }: { block: StatsBlock }) {
+  return (
+    <section className={`${styles.block} ${styles.wide}`}>
+      {block.heading && <h2 className={styles.blockHeading}>{block.heading}</h2>}
+      <dl className={styles.statsRow}>
+        {block.items.map((item, i) => (
+          <div key={i} className={styles.statItem}>
+            <dt className={styles.statValue}>{item.value}</dt>
+            <dd className={styles.statLabel}>
+              <span className={styles.statLabelText}>{item.label}</span>
+              {item.caption && <span className={styles.statCaption}>{item.caption}</span>}
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/src/components/ProjectBlocks/TechStack.tsx
+++ b/src/components/ProjectBlocks/TechStack.tsx
@@ -1,0 +1,33 @@
+import type { TechStackBlock } from "./blocks";
+import styles from "./ProjectBlocks.module.scss";
+
+/**
+ * Technologies used, laid out as a spec table: each group is a row with its label
+ * on the left and wrapping chips on the right (hairline-separated). This keeps
+ * uneven groups tidy — a one-item group and a ten-item group sit on their own rows
+ * instead of leaving a column gap. The label column is a <dt>, the chips a <ul>,
+ * so the structure is announced. Rows stack (label above chips) on mobile.
+ */
+export default function TechStack({ block }: { block: TechStackBlock }) {
+  return (
+    <section className={`${styles.block} ${styles.wide}`}>
+      {block.heading && <h2 className={styles.blockHeading}>{block.heading}</h2>}
+      <dl className={styles.techTable}>
+        {block.groups.map((group, i) => (
+          <div key={i} className={styles.techRow}>
+            <dt className={styles.techRowLabel}>{group.label}</dt>
+            <dd className={styles.techRowItems}>
+              <ul className={styles.techChips}>
+                {group.items.map((item, j) => (
+                  <li key={j} className={styles.techChip}>
+                    {item}
+                  </li>
+                ))}
+              </ul>
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </section>
+  );
+}

--- a/src/components/ProjectBlocks/Video.tsx
+++ b/src/components/ProjectBlocks/Video.tsx
@@ -1,0 +1,29 @@
+import type { VideoBlock } from "./blocks";
+import styles from "./ProjectBlocks.module.scss";
+
+/**
+ * Embedded video clip. Native <video controls> so it works without extra client
+ * JS and stays keyboard-operable; never autoplays (respects users who don't want
+ * motion). `preload="metadata"` keeps the page light until the user hits play.
+ */
+export default function Video({ block }: { block: VideoBlock }) {
+  return (
+    <section className={`${styles.block} ${styles.measure}`}>
+      <figure className={styles.videoFigure}>
+        <video
+          className={styles.video}
+          controls
+          preload="metadata"
+          playsInline
+          poster={block.poster?.src}
+          aria-label={block.caption || "Project video"}
+        >
+          <source src={block.src} type={block.mimeType || "video/mp4"} />
+          Your browser doesn&rsquo;t support embedded video.{" "}
+          <a href={block.src}>Download the video</a> instead.
+        </video>
+        {block.caption && <figcaption className={styles.videoCaption}>{block.caption}</figcaption>}
+      </figure>
+    </section>
+  );
+}

--- a/src/components/ProjectBlocks/blocks.ts
+++ b/src/components/ProjectBlocks/blocks.ts
@@ -1,0 +1,453 @@
+// Shared block model for project case-study pages. The whole ordered list lives
+// in the Project.projectPage JSON field (nullable — null means "no blocks yet").
+//
+// This module is dependency-free and safe to import on both the server (the
+// updateProjectPage action validates with `sanitizeProjectPage`) and the client
+// (the editor builds new blocks with the `create*` helpers). The frontend owns
+// all layout — blocks carry content only, never columns/breakpoints.
+
+import { isSafeUrl, sanitizeRichTextAst } from "@/components/RichTextEditor/richTextAst";
+import type { MediaAsset } from "@/lib/getAssets";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type BlockType =
+  | "hero"
+  | "richText"
+  | "featureGrid"
+  | "stats"
+  | "techStack"
+  | "gallery"
+  | "video"
+  | "callout"
+  | "cta";
+
+/** A self-contained image reference mirroring the fields Hygraph assets expose. */
+export type ImageRef = {
+  src: string;
+  handle?: string;
+  width?: number;
+  height?: number;
+  alt?: string;
+};
+
+export type HeroBlock = {
+  id: string;
+  type: "hero";
+  eyebrow?: string;
+  headline: string;
+  summary?: string;
+  /** Free-form "Label: Value" facts (Role, Timeline, Team…). Rendered as chips. */
+  roleItems?: string[];
+  image?: ImageRef;
+  /** Up to 2 call-to-action links. hrefs are validated with isSafeUrl. */
+  actions?: { label: string; href: string }[];
+};
+
+export type RichTextBlock = {
+  id: string;
+  type: "richText";
+  /** Hygraph rich-text AST ({ children }) — the existing editor's payload. */
+  content: { children: any[] };
+};
+
+export type FeatureItem = { title: string; description?: string };
+export type FeatureGridBlock = {
+  id: string;
+  type: "featureGrid";
+  heading?: string;
+  /** Items render as compact tiles when none have a description, larger cards
+   *  when any do — the frontend decides; the author just supplies content. */
+  items: FeatureItem[];
+};
+
+export type StatItem = { value: string; label: string; caption?: string };
+export type StatsBlock = {
+  id: string;
+  type: "stats";
+  heading?: string;
+  items: StatItem[]; // 2–6
+};
+
+export type TechGroup = { label: string; items: string[] };
+export type TechStackBlock = {
+  id: string;
+  type: "techStack";
+  heading?: string;
+  groups: TechGroup[];
+};
+
+export type GalleryImage = ImageRef & { caption?: string };
+export type GalleryBlock = {
+  id: string;
+  type: "gallery";
+  heading?: string;
+  images: GalleryImage[]; // 1+
+  /** Layout hint the frontend interprets — never pixel layout. */
+  layout?: "auto" | "wide";
+};
+
+export type VideoBlock = {
+  id: string;
+  type: "video";
+  src: string;
+  mimeType?: string;
+  /** Optional still shown before playback. */
+  poster?: ImageRef;
+  caption?: string;
+};
+
+export type CalloutVariant = "quote" | "info" | "success" | "warning";
+export type CalloutBlock = {
+  id: string;
+  type: "callout";
+  variant: CalloutVariant;
+  text: string;
+  attribution?: string;
+};
+
+export type CtaBlock = {
+  id: string;
+  type: "cta";
+  heading?: string;
+  text?: string;
+  label: string;
+  href: string;
+};
+
+export type Block =
+  | HeroBlock
+  | RichTextBlock
+  | FeatureGridBlock
+  | StatsBlock
+  | TechStackBlock
+  | GalleryBlock
+  | VideoBlock
+  | CalloutBlock
+  | CtaBlock;
+
+// Per-block authoring constraints, shared by the editor (guardrails) and the
+// server validator (defense in depth).
+export const STATS_MIN = 2;
+export const STATS_MAX = 6;
+export const HERO_MAX_ACTIONS = 2;
+export const CALLOUT_VARIANTS: CalloutVariant[] = ["quote", "info", "success", "warning"];
+
+export const BLOCK_LABELS: Record<BlockType, string> = {
+  hero: "Hero",
+  richText: "Rich text",
+  featureGrid: "Feature grid",
+  stats: "Stats",
+  techStack: "Tech stack",
+  gallery: "Gallery",
+  video: "Video",
+  callout: "Callout",
+  cta: "Call to action"
+};
+
+// A short, author-facing description shown in the "Add block" palette.
+export const BLOCK_DESCRIPTIONS: Record<BlockType, string> = {
+  hero: "Project header with summary, key facts and a lead image.",
+  richText: "Formatted prose — headings, lists, links and inline images.",
+  featureGrid: "Features or capabilities as a responsive card grid.",
+  stats: "Impact metrics shown as a responsive number grid.",
+  techStack: "Technologies used, grouped into labelled chips.",
+  gallery: "Screenshots or diagrams with captions and a lightbox.",
+  video: "An embedded video clip with an optional caption.",
+  callout: "A pull quote or highlighted note to break up the page.",
+  cta: "A closing prompt with a button link (e.g. View on GitHub)."
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Stable id for React keys + reordering. */
+export function newBlockId(): string {
+  if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+    return crypto.randomUUID();
+  }
+  return `b_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
+}
+
+const EMPTY_RICH_TEXT = { children: [{ type: "paragraph", children: [{ text: "" }] }] };
+
+/** Convert a media-library asset to the block ImageRef shape. */
+export function assetToImageRef(asset: MediaAsset): ImageRef {
+  const ref: ImageRef = { src: asset.url };
+  if (asset.handle) ref.handle = asset.handle;
+  if (asset.width != null) ref.width = asset.width;
+  if (asset.height != null) ref.height = asset.height;
+  const name = asset.title?.trim() || asset.fileName;
+  if (name) ref.alt = name;
+  return ref;
+}
+
+/** Pull the src + mimeType from a media-library asset for a video block. */
+export function assetToVideoRef(asset: MediaAsset): { src: string; mimeType?: string } {
+  return asset.mimeType ? { src: asset.url, mimeType: asset.mimeType } : { src: asset.url };
+}
+
+/** Build a fresh block of `type` with sensible defaults. `projectTitle` seeds the hero. */
+export function createBlock(type: BlockType, projectTitle = ""): Block {
+  const id = newBlockId();
+  switch (type) {
+    case "hero":
+      return { id, type, headline: projectTitle || "Project title", roleItems: [] };
+    case "richText":
+      return { id, type, content: { children: EMPTY_RICH_TEXT.children.map((c) => ({ ...c })) } };
+    case "featureGrid":
+      return { id, type, items: [{ title: "" }, { title: "" }, { title: "" }] };
+    case "stats":
+      return {
+        id,
+        type,
+        items: [
+          { value: "", label: "" },
+          { value: "", label: "" },
+          { value: "", label: "" }
+        ]
+      };
+    case "techStack":
+      return { id, type, groups: [{ label: "", items: [] }] };
+    case "gallery":
+      return { id, type, images: [], layout: "auto" };
+    case "video":
+      return { id, type, src: "" };
+    case "callout":
+      return { id, type, variant: "info", text: "" };
+    case "cta":
+      return { id, type, label: "", href: "" };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Validation / sanitization
+// ---------------------------------------------------------------------------
+
+function str(v: any): string {
+  return typeof v === "string" ? v : "";
+}
+function trimmed(v: any): string {
+  return str(v).trim();
+}
+function optStr(v: any): string | undefined {
+  const t = trimmed(v);
+  return t ? t : undefined;
+}
+function num(v: any): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function cleanImageRef(v: any): ImageRef | undefined {
+  const src = trimmed(v?.src);
+  if (!src || !isSafeUrl(src)) return undefined;
+  const ref: ImageRef = { src };
+  const handle = optStr(v?.handle);
+  if (handle) ref.handle = handle;
+  const w = num(v?.width);
+  if (w != null) ref.width = w;
+  const h = num(v?.height);
+  if (h != null) ref.height = h;
+  const alt = optStr(v?.alt);
+  if (alt) ref.alt = alt;
+  return ref;
+}
+
+function cleanHero(b: any, id: string): HeroBlock | null {
+  const headline = trimmed(b.headline);
+  if (!headline) return null; // headline is required
+  const out: HeroBlock = { id, type: "hero", headline };
+  const eyebrow = optStr(b.eyebrow);
+  if (eyebrow) out.eyebrow = eyebrow;
+  const summary = optStr(b.summary);
+  if (summary) out.summary = summary;
+  if (Array.isArray(b.roleItems)) {
+    const items = b.roleItems.map(trimmed).filter(Boolean);
+    if (items.length) out.roleItems = items;
+  }
+  const image = cleanImageRef(b.image);
+  if (image) out.image = image;
+  if (Array.isArray(b.actions)) {
+    const actions = b.actions
+      .map((a: any) => ({ label: trimmed(a?.label), href: trimmed(a?.href) }))
+      .filter((a: any) => a.label && a.href && isSafeUrl(a.href))
+      .slice(0, HERO_MAX_ACTIONS);
+    if (actions.length) out.actions = actions;
+  }
+  return out;
+}
+
+function cleanRichText(b: any, id: string): RichTextBlock | null {
+  const content = b?.content;
+  if (!content || !Array.isArray(content.children)) return null;
+  return { id, type: "richText", content: sanitizeRichTextAst(content) };
+}
+
+function cleanFeatureGrid(b: any, id: string): FeatureGridBlock | null {
+  if (!Array.isArray(b.items)) return null;
+  const items = b.items
+    .map((it: any) => {
+      const title = trimmed(it?.title);
+      if (!title) return null;
+      const item: FeatureItem = { title };
+      const description = optStr(it?.description);
+      if (description) item.description = description;
+      return item;
+    })
+    .filter(Boolean) as FeatureItem[];
+  if (items.length === 0) return null;
+  const out: FeatureGridBlock = { id, type: "featureGrid", items };
+  const heading = optStr(b.heading);
+  if (heading) out.heading = heading;
+  return out;
+}
+
+function cleanStats(b: any, id: string): StatsBlock | null {
+  if (!Array.isArray(b.items)) return null;
+  const items = b.items
+    .map((it: any) => {
+      const value = trimmed(it?.value);
+      const label = trimmed(it?.label);
+      if (!value || !label) return null;
+      const item: StatItem = { value, label };
+      const caption = optStr(it?.caption);
+      if (caption) item.caption = caption;
+      return item;
+    })
+    .filter(Boolean)
+    .slice(0, STATS_MAX) as StatItem[];
+  if (items.length < STATS_MIN) return null; // not enough valid stats to render
+  const out: StatsBlock = { id, type: "stats", items };
+  const heading = optStr(b.heading);
+  if (heading) out.heading = heading;
+  return out;
+}
+
+function cleanTechStack(b: any, id: string): TechStackBlock | null {
+  if (!Array.isArray(b.groups)) return null;
+  const groups = b.groups
+    .map((g: any) => {
+      const label = trimmed(g?.label);
+      const items = Array.isArray(g?.items) ? g.items.map(trimmed).filter(Boolean) : [];
+      if (!label || items.length === 0) return null;
+      return { label, items } as TechGroup;
+    })
+    .filter(Boolean) as TechGroup[];
+  if (groups.length === 0) return null;
+  const out: TechStackBlock = { id, type: "techStack", groups };
+  const heading = optStr(b.heading);
+  if (heading) out.heading = heading;
+  return out;
+}
+
+function cleanGallery(b: any, id: string): GalleryBlock | null {
+  if (!Array.isArray(b.images)) return null;
+  const images = b.images
+    .map((img: any) => {
+      const ref = cleanImageRef(img);
+      if (!ref) return null;
+      const caption = optStr(img?.caption);
+      return (caption ? { ...ref, caption } : ref) as GalleryImage;
+    })
+    .filter(Boolean) as GalleryImage[];
+  if (images.length === 0) return null;
+  const out: GalleryBlock = { id, type: "gallery", images };
+  out.layout = b.layout === "wide" ? "wide" : "auto";
+  const heading = optStr(b.heading);
+  if (heading) out.heading = heading;
+  return out;
+}
+
+function cleanVideo(b: any, id: string): VideoBlock | null {
+  const src = trimmed(b.src);
+  if (!src || !isSafeUrl(src)) return null;
+  const out: VideoBlock = { id, type: "video", src };
+  const mimeType = optStr(b.mimeType);
+  if (mimeType) out.mimeType = mimeType;
+  const poster = cleanImageRef(b.poster);
+  if (poster) out.poster = poster;
+  const caption = optStr(b.caption);
+  if (caption) out.caption = caption;
+  return out;
+}
+
+function cleanCallout(b: any, id: string): CalloutBlock | null {
+  const text = trimmed(b.text);
+  if (!text) return null;
+  const variant: CalloutVariant = CALLOUT_VARIANTS.includes(b.variant) ? b.variant : "info";
+  const out: CalloutBlock = { id, type: "callout", variant, text };
+  const attribution = optStr(b.attribution);
+  if (attribution) out.attribution = attribution;
+  return out;
+}
+
+function cleanCta(b: any, id: string): CtaBlock | null {
+  const label = trimmed(b.label);
+  const href = trimmed(b.href);
+  if (!label || !href || !isSafeUrl(href)) return null;
+  const out: CtaBlock = { id, type: "cta", label, href };
+  const heading = optStr(b.heading);
+  if (heading) out.heading = heading;
+  const text = optStr(b.text);
+  if (text) out.text = text;
+  return out;
+}
+
+/**
+ * Validate + sanitize an arbitrary value into a clean Block[]. Used server-side
+ * before persisting and (defensively) when reading. Unknown/invalid blocks are
+ * dropped rather than throwing, so one bad block can never break the page.
+ * Returns [] for null/undefined/non-arrays (a project with no blocks yet).
+ */
+export function sanitizeProjectPage(raw: any): Block[] {
+  if (!Array.isArray(raw)) return [];
+  const out: Block[] = [];
+  let heroSeen = false;
+
+  for (const b of raw) {
+    if (!b || typeof b !== "object") continue;
+    const id = trimmed(b.id) || newBlockId();
+    let cleaned: Block | null = null;
+
+    switch (b.type) {
+      case "hero":
+        if (heroSeen) continue; // at most one hero per page
+        cleaned = cleanHero(b, id);
+        if (cleaned) heroSeen = true;
+        break;
+      case "richText":
+        cleaned = cleanRichText(b, id);
+        break;
+      case "featureGrid":
+        cleaned = cleanFeatureGrid(b, id);
+        break;
+      case "stats":
+        cleaned = cleanStats(b, id);
+        break;
+      case "techStack":
+        cleaned = cleanTechStack(b, id);
+        break;
+      case "gallery":
+        cleaned = cleanGallery(b, id);
+        break;
+      case "video":
+        cleaned = cleanVideo(b, id);
+        break;
+      case "callout":
+        cleaned = cleanCallout(b, id);
+        break;
+      case "cta":
+        cleaned = cleanCta(b, id);
+        break;
+      default:
+        continue;
+    }
+
+    if (cleaned) out.push(cleaned);
+  }
+
+  return out;
+}

--- a/src/components/ProjectBlocks/editor/BlockForms.tsx
+++ b/src/components/ProjectBlocks/editor/BlockForms.tsx
@@ -1,0 +1,833 @@
+"use client";
+
+import { useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus, faTrash, faImage, faVideo, faArrowUp, faArrowDown } from "@fortawesome/free-solid-svg-icons";
+import AssetPicker from "@/components/RichTextEditor/AssetPicker";
+import { isSafeUrl } from "@/components/RichTextEditor/richTextAst";
+import type { MediaAsset } from "@/lib/getAssets";
+import {
+  assetToImageRef,
+  assetToVideoRef,
+  CALLOUT_VARIANTS,
+  STATS_MAX,
+  STATS_MIN,
+  HERO_MAX_ACTIONS,
+  type HeroBlock,
+  type FeatureGridBlock,
+  type StatsBlock,
+  type TechStackBlock,
+  type GalleryBlock,
+  type VideoBlock,
+  type CalloutBlock,
+  type CtaBlock,
+  type GalleryImage
+} from "../blocks";
+import styles from "./ProjectPageEditor.module.scss";
+
+// Each form is controlled: it receives the draft block and emits the next draft
+// on every change. The orchestrator owns Save/Cancel and persistence; these
+// components only collect input and surface inline guardrails. The matching
+// `isBlockComplete` check (below) mirrors the server's sanitize rules so a block
+// can't be saved into a state that would be silently dropped.
+
+// ---------------------------------------------------------------------------
+// Completeness (client guardrail mirroring sanitizeProjectPage)
+// ---------------------------------------------------------------------------
+
+export function isBlockComplete(block: any): boolean {
+  switch (block?.type) {
+    case "hero":
+      return !!String(block.headline ?? "").trim();
+    case "richText":
+      return Array.isArray(block.content?.children);
+    case "featureGrid":
+      return (
+        Array.isArray(block.items) &&
+        block.items.some((i: any) => String(i?.title ?? "").trim())
+      );
+    case "stats":
+      return (
+        Array.isArray(block.items) &&
+        block.items.filter((i: any) => String(i?.value ?? "").trim() && String(i?.label ?? "").trim())
+          .length >= STATS_MIN
+      );
+    case "techStack":
+      return (
+        Array.isArray(block.groups) &&
+        block.groups.some(
+          (g: any) => String(g?.label ?? "").trim() && Array.isArray(g?.items) && g.items.length > 0
+        )
+      );
+    case "gallery":
+      return Array.isArray(block.images) && block.images.some((i: any) => String(i?.src ?? "").trim());
+    case "video":
+      return !!String(block.src ?? "").trim();
+    case "callout":
+      return !!String(block.text ?? "").trim();
+    case "cta":
+      return !!String(block.label ?? "").trim() && !!String(block.href ?? "").trim();
+    default:
+      return false;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Small shared field helpers
+// ---------------------------------------------------------------------------
+
+function Field({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <label className={styles.field}>
+      <span className={styles.fieldLabel}>{label}</span>
+      {children}
+    </label>
+  );
+}
+
+function MediaPickerButton({
+  onPick,
+  label,
+  accept = "image",
+  icon = faImage
+}: {
+  onPick: (a: MediaAsset) => void;
+  label: string;
+  accept?: "image" | "video";
+  icon?: typeof faImage;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" className={styles.secondaryBtn} onClick={() => setOpen(true)}>
+        <FontAwesomeIcon icon={icon} /> {label}
+      </button>
+      {open && (
+        <AssetPicker
+          title={label}
+          accept={accept}
+          onSelect={(asset) => {
+            onPick(asset);
+            setOpen(false);
+          }}
+          onClose={() => setOpen(false)}
+        />
+      )}
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Hero
+// ---------------------------------------------------------------------------
+
+export function HeroForm({
+  block,
+  onChange
+}: {
+  block: HeroBlock;
+  onChange: (b: HeroBlock) => void;
+}) {
+  const roleItems = block.roleItems ?? [];
+  const actions = block.actions ?? [];
+
+  return (
+    <div className={styles.form}>
+      <Field label="Eyebrow (optional)">
+        <input
+          type="text"
+          value={block.eyebrow ?? ""}
+          placeholder="e.g. Web Application"
+          onChange={(e) => onChange({ ...block, eyebrow: e.target.value })}
+        />
+      </Field>
+
+      <Field label="Headline (required)">
+        <input
+          type="text"
+          value={block.headline}
+          onChange={(e) => onChange({ ...block, headline: e.target.value })}
+        />
+      </Field>
+
+      <Field label="Summary (optional)">
+        <textarea
+          rows={3}
+          value={block.summary ?? ""}
+          onChange={(e) => onChange({ ...block, summary: e.target.value })}
+        />
+      </Field>
+
+      <fieldset className={styles.subgroup}>
+        <legend>Key facts</legend>
+        {roleItems.map((item, i) => (
+          <div key={i} className={styles.row}>
+            <input
+              type="text"
+              value={item}
+              placeholder="e.g. Role: Lead Engineer"
+              onChange={(e) => {
+                const next = [...roleItems];
+                next[i] = e.target.value;
+                onChange({ ...block, roleItems: next });
+              }}
+            />
+            <button
+              type="button"
+              className={styles.iconBtn}
+              aria-label={`Remove fact ${i + 1}`}
+              onClick={() => onChange({ ...block, roleItems: roleItems.filter((_, j) => j !== i) })}
+            >
+              <FontAwesomeIcon icon={faTrash} />
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          className={styles.addRowBtn}
+          onClick={() => onChange({ ...block, roleItems: [...roleItems, ""] })}
+        >
+          <FontAwesomeIcon icon={faPlus} /> Add fact
+        </button>
+      </fieldset>
+
+      <fieldset className={styles.subgroup}>
+        <legend>Lead image</legend>
+        {block.image?.src && (
+          <div className={styles.imagePreviewRow}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={block.image.src} alt="" className={styles.imagePreview} />
+            <button
+              type="button"
+              className={styles.iconBtn}
+              aria-label="Remove image"
+              onClick={() => onChange({ ...block, image: undefined })}
+            >
+              <FontAwesomeIcon icon={faTrash} />
+            </button>
+          </div>
+        )}
+        <MediaPickerButton
+          label={block.image ? "Replace image" : "Add image"}
+          onPick={(asset) => onChange({ ...block, image: assetToImageRef(asset) })}
+        />
+        {block.image?.src && (
+          <Field label="Image alt text (describe the image; leave blank if decorative)">
+            <input
+              type="text"
+              value={block.image.alt ?? ""}
+              onChange={(e) =>
+                onChange({ ...block, image: { ...block.image!, alt: e.target.value } })
+              }
+            />
+          </Field>
+        )}
+      </fieldset>
+
+      <fieldset className={styles.subgroup}>
+        <legend>Buttons (up to {HERO_MAX_ACTIONS})</legend>
+        {actions.map((action, i) => {
+          const invalid = action.href.trim() !== "" && !isSafeUrl(action.href);
+          return (
+            <div key={i} className={styles.actionRow}>
+              <input
+                type="text"
+                value={action.label}
+                placeholder="Button label"
+                onChange={(e) => {
+                  const next = [...actions];
+                  next[i] = { ...next[i], label: e.target.value };
+                  onChange({ ...block, actions: next });
+                }}
+              />
+              <input
+                type="text"
+                value={action.href}
+                placeholder="https://… or /path"
+                aria-invalid={invalid}
+                onChange={(e) => {
+                  const next = [...actions];
+                  next[i] = { ...next[i], href: e.target.value };
+                  onChange({ ...block, actions: next });
+                }}
+              />
+              <button
+                type="button"
+                className={styles.iconBtn}
+                aria-label={`Remove button ${i + 1}`}
+                onClick={() => onChange({ ...block, actions: actions.filter((_, j) => j !== i) })}
+              >
+                <FontAwesomeIcon icon={faTrash} />
+              </button>
+            </div>
+          );
+        })}
+        {actions.length < HERO_MAX_ACTIONS && (
+          <button
+            type="button"
+            className={styles.addRowBtn}
+            onClick={() => onChange({ ...block, actions: [...actions, { label: "", href: "" }] })}
+          >
+            <FontAwesomeIcon icon={faPlus} /> Add button
+          </button>
+        )}
+      </fieldset>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+export function StatsForm({
+  block,
+  onChange
+}: {
+  block: StatsBlock;
+  onChange: (b: StatsBlock) => void;
+}) {
+  const items = block.items ?? [];
+  return (
+    <div className={styles.form}>
+      <Field label="Heading (optional)">
+        <input
+          type="text"
+          value={block.heading ?? ""}
+          placeholder="e.g. Results"
+          onChange={(e) => onChange({ ...block, heading: e.target.value })}
+        />
+      </Field>
+
+      <fieldset className={styles.subgroup}>
+        <legend>
+          Metrics ({STATS_MIN}–{STATS_MAX})
+        </legend>
+        {items.map((item, i) => (
+          <div key={i} className={styles.statRow}>
+            <input
+              type="text"
+              value={item.value}
+              placeholder="Value (e.g. 40%)"
+              onChange={(e) => {
+                const next = [...items];
+                next[i] = { ...next[i], value: e.target.value };
+                onChange({ ...block, items: next });
+              }}
+            />
+            <input
+              type="text"
+              value={item.label}
+              placeholder="Label (e.g. faster builds)"
+              onChange={(e) => {
+                const next = [...items];
+                next[i] = { ...next[i], label: e.target.value };
+                onChange({ ...block, items: next });
+              }}
+            />
+            <input
+              type="text"
+              value={item.caption ?? ""}
+              placeholder="Caption (optional)"
+              onChange={(e) => {
+                const next = [...items];
+                next[i] = { ...next[i], caption: e.target.value };
+                onChange({ ...block, items: next });
+              }}
+            />
+            <button
+              type="button"
+              className={styles.iconBtn}
+              aria-label={`Remove metric ${i + 1}`}
+              disabled={items.length <= STATS_MIN}
+              onClick={() => onChange({ ...block, items: items.filter((_, j) => j !== i) })}
+            >
+              <FontAwesomeIcon icon={faTrash} />
+            </button>
+          </div>
+        ))}
+        {items.length < STATS_MAX && (
+          <button
+            type="button"
+            className={styles.addRowBtn}
+            onClick={() => onChange({ ...block, items: [...items, { value: "", label: "" }] })}
+          >
+            <FontAwesomeIcon icon={faPlus} /> Add metric
+          </button>
+        )}
+      </fieldset>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tech stack
+// ---------------------------------------------------------------------------
+
+export function TechStackForm({
+  block,
+  onChange
+}: {
+  block: TechStackBlock;
+  onChange: (b: TechStackBlock) => void;
+}) {
+  const groups = block.groups ?? [];
+  const [chipDrafts, setChipDrafts] = useState<Record<number, string>>({});
+
+  function commitChip(groupIndex: number) {
+    const raw = (chipDrafts[groupIndex] ?? "").trim();
+    if (!raw) return;
+    // Allow comma-separated entry: "React, TypeScript".
+    const additions = raw.split(",").map((s) => s.trim()).filter(Boolean);
+    const next = groups.map((g, i) =>
+      i === groupIndex ? { ...g, items: [...g.items, ...additions] } : g
+    );
+    onChange({ ...block, groups: next });
+    setChipDrafts((d) => ({ ...d, [groupIndex]: "" }));
+  }
+
+  return (
+    <div className={styles.form}>
+      <Field label="Heading (optional)">
+        <input
+          type="text"
+          value={block.heading ?? ""}
+          placeholder="e.g. Built with"
+          onChange={(e) => onChange({ ...block, heading: e.target.value })}
+        />
+      </Field>
+
+      {groups.map((group, gi) => (
+        <fieldset key={gi} className={styles.subgroup}>
+          <legend>Group {gi + 1}</legend>
+          <div className={styles.row}>
+            <input
+              type="text"
+              value={group.label}
+              placeholder="Group label (e.g. Frontend)"
+              onChange={(e) => {
+                const next = [...groups];
+                next[gi] = { ...next[gi], label: e.target.value };
+                onChange({ ...block, groups: next });
+              }}
+            />
+            <button
+              type="button"
+              className={styles.iconBtn}
+              aria-label={`Remove group ${gi + 1}`}
+              onClick={() => onChange({ ...block, groups: groups.filter((_, j) => j !== gi) })}
+            >
+              <FontAwesomeIcon icon={faTrash} />
+            </button>
+          </div>
+
+          {group.items.length > 0 && (
+            <ul className={styles.chipList}>
+              {group.items.map((item, ii) => (
+                <li key={ii} className={styles.editChip}>
+                  {item}
+                  <button
+                    type="button"
+                    aria-label={`Remove ${item}`}
+                    onClick={() => {
+                      const next = [...groups];
+                      next[gi] = { ...next[gi], items: next[gi].items.filter((_, j) => j !== ii) };
+                      onChange({ ...block, groups: next });
+                    }}
+                  >
+                    ×
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          <div className={styles.row}>
+            <input
+              type="text"
+              value={chipDrafts[gi] ?? ""}
+              placeholder="Add technology, press Enter"
+              onChange={(e) => setChipDrafts((d) => ({ ...d, [gi]: e.target.value }))}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === ",") {
+                  e.preventDefault();
+                  commitChip(gi);
+                }
+              }}
+            />
+            <button type="button" className={styles.secondaryBtn} onClick={() => commitChip(gi)}>
+              <FontAwesomeIcon icon={faPlus} /> Add
+            </button>
+          </div>
+        </fieldset>
+      ))}
+
+      <button
+        type="button"
+        className={styles.addRowBtn}
+        onClick={() => onChange({ ...block, groups: [...groups, { label: "", items: [] }] })}
+      >
+        <FontAwesomeIcon icon={faPlus} /> Add group
+      </button>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Gallery
+// ---------------------------------------------------------------------------
+
+export function GalleryForm({
+  block,
+  onChange
+}: {
+  block: GalleryBlock;
+  onChange: (b: GalleryBlock) => void;
+}) {
+  const images = block.images ?? [];
+
+  function update(i: number, patch: Partial<GalleryImage>) {
+    const next = [...images];
+    next[i] = { ...next[i], ...patch };
+    onChange({ ...block, images: next });
+  }
+
+  function move(from: number, to: number) {
+    if (to < 0 || to >= images.length) return;
+    const next = [...images];
+    const [moved] = next.splice(from, 1);
+    next.splice(to, 0, moved);
+    onChange({ ...block, images: next });
+  }
+
+  return (
+    <div className={styles.form}>
+      <Field label="Heading (optional)">
+        <input
+          type="text"
+          value={block.heading ?? ""}
+          placeholder="e.g. Screenshots"
+          onChange={(e) => onChange({ ...block, heading: e.target.value })}
+        />
+      </Field>
+
+      <Field label="Size">
+        <select
+          value={block.layout ?? "auto"}
+          onChange={(e) => onChange({ ...block, layout: e.target.value === "wide" ? "wide" : "auto" })}
+        >
+          <option value="auto">Standard grid</option>
+          <option value="wide">Larger tiles</option>
+        </select>
+      </Field>
+
+      <fieldset className={styles.subgroup}>
+        <legend>Images</legend>
+        {images.map((img, i) => (
+          <div key={i} className={styles.galleryEditRow}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={img.src} alt="" className={styles.imagePreview} />
+            <div className={styles.galleryEditFields}>
+              <input
+                type="text"
+                value={img.alt ?? ""}
+                placeholder="Alt text (leave blank if decorative)"
+                onChange={(e) => update(i, { alt: e.target.value })}
+              />
+              <input
+                type="text"
+                value={img.caption ?? ""}
+                placeholder="Caption (optional)"
+                onChange={(e) => update(i, { caption: e.target.value })}
+              />
+            </div>
+            <div className={styles.galleryEditActions}>
+              <button
+                type="button"
+                className={styles.iconBtn}
+                aria-label={`Move image ${i + 1} up`}
+                disabled={i === 0}
+                onClick={() => move(i, i - 1)}
+              >
+                <FontAwesomeIcon icon={faArrowUp} />
+              </button>
+              <button
+                type="button"
+                className={styles.iconBtn}
+                aria-label={`Move image ${i + 1} down`}
+                disabled={i === images.length - 1}
+                onClick={() => move(i, i + 1)}
+              >
+                <FontAwesomeIcon icon={faArrowDown} />
+              </button>
+              <button
+                type="button"
+                className={styles.iconBtn}
+                aria-label={`Remove image ${i + 1}`}
+                onClick={() => onChange({ ...block, images: images.filter((_, j) => j !== i) })}
+              >
+                <FontAwesomeIcon icon={faTrash} />
+              </button>
+            </div>
+          </div>
+        ))}
+        <MediaPickerButton
+          label="Add image"
+          onPick={(asset) =>
+            onChange({ ...block, images: [...images, assetToImageRef(asset)] })
+          }
+        />
+      </fieldset>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Video
+// ---------------------------------------------------------------------------
+
+export function VideoForm({
+  block,
+  onChange
+}: {
+  block: VideoBlock;
+  onChange: (b: VideoBlock) => void;
+}) {
+  return (
+    <div className={styles.form}>
+      <fieldset className={styles.subgroup}>
+        <legend>Video</legend>
+        {block.src ? (
+          <div className={styles.imagePreviewRow}>
+            {/* eslint-disable-next-line jsx-a11y/media-has-caption */}
+            <video src={block.src} muted preload="metadata" className={styles.imagePreview} />
+            <button
+              type="button"
+              className={styles.iconBtn}
+              aria-label="Remove video"
+              onClick={() => onChange({ ...block, src: "", mimeType: undefined })}
+            >
+              <FontAwesomeIcon icon={faTrash} />
+            </button>
+          </div>
+        ) : (
+          <p className={styles.fieldLabel}>No video selected yet.</p>
+        )}
+        <MediaPickerButton
+          accept="video"
+          icon={faVideo}
+          label={block.src ? "Replace video" : "Choose video"}
+          onPick={(asset) => onChange({ ...block, ...assetToVideoRef(asset) })}
+        />
+      </fieldset>
+
+      <fieldset className={styles.subgroup}>
+        <legend>Poster image (optional)</legend>
+        {block.poster?.src && (
+          <div className={styles.imagePreviewRow}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={block.poster.src} alt="" className={styles.imagePreview} />
+            <button
+              type="button"
+              className={styles.iconBtn}
+              aria-label="Remove poster"
+              onClick={() => onChange({ ...block, poster: undefined })}
+            >
+              <FontAwesomeIcon icon={faTrash} />
+            </button>
+          </div>
+        )}
+        <MediaPickerButton
+          label={block.poster ? "Replace poster" : "Add poster"}
+          onPick={(asset) => onChange({ ...block, poster: assetToImageRef(asset) })}
+        />
+      </fieldset>
+
+      <Field label="Caption (optional)">
+        <input
+          type="text"
+          value={block.caption ?? ""}
+          onChange={(e) => onChange({ ...block, caption: e.target.value })}
+        />
+      </Field>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Feature grid
+// ---------------------------------------------------------------------------
+
+export function FeatureGridForm({
+  block,
+  onChange
+}: {
+  block: FeatureGridBlock;
+  onChange: (b: FeatureGridBlock) => void;
+}) {
+  const items = block.items ?? [];
+
+  return (
+    <div className={styles.form}>
+      <Field label="Heading (optional)">
+        <input
+          type="text"
+          value={block.heading ?? ""}
+          placeholder="e.g. Key Features"
+          onChange={(e) => onChange({ ...block, heading: e.target.value })}
+        />
+      </Field>
+
+      <fieldset className={styles.subgroup}>
+        <legend>Items</legend>
+        <p className={styles.fieldLabel}>
+          Add a description to any item to switch the whole grid to larger cards.
+        </p>
+        {items.map((item, i) => (
+          <div key={i} className={styles.featureEditRow}>
+            <div className={styles.featureEditFields}>
+              <input
+                type="text"
+                value={item.title}
+                placeholder="Title (e.g. Ray tracing)"
+                onChange={(e) => {
+                  const next = [...items];
+                  next[i] = { ...next[i], title: e.target.value };
+                  onChange({ ...block, items: next });
+                }}
+              />
+              <textarea
+                rows={2}
+                value={item.description ?? ""}
+                placeholder="Description (optional)"
+                onChange={(e) => {
+                  const next = [...items];
+                  next[i] = { ...next[i], description: e.target.value };
+                  onChange({ ...block, items: next });
+                }}
+              />
+            </div>
+            <button
+              type="button"
+              className={styles.iconBtn}
+              aria-label={`Remove item ${i + 1}`}
+              disabled={items.length <= 1}
+              onClick={() => onChange({ ...block, items: items.filter((_, j) => j !== i) })}
+            >
+              <FontAwesomeIcon icon={faTrash} />
+            </button>
+          </div>
+        ))}
+        <button
+          type="button"
+          className={styles.addRowBtn}
+          onClick={() => onChange({ ...block, items: [...items, { title: "" }] })}
+        >
+          <FontAwesomeIcon icon={faPlus} /> Add item
+        </button>
+      </fieldset>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Callout
+// ---------------------------------------------------------------------------
+
+export function CalloutForm({
+  block,
+  onChange
+}: {
+  block: CalloutBlock;
+  onChange: (b: CalloutBlock) => void;
+}) {
+  return (
+    <div className={styles.form}>
+      <Field label="Style">
+        <select
+          value={block.variant}
+          onChange={(e) => onChange({ ...block, variant: e.target.value as CalloutBlock["variant"] })}
+        >
+          {CALLOUT_VARIANTS.map((v) => (
+            <option key={v} value={v}>
+              {v === "quote" ? "Pull quote" : v.charAt(0).toUpperCase() + v.slice(1)}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label="Text (required)">
+        <textarea
+          rows={3}
+          value={block.text}
+          onChange={(e) => onChange({ ...block, text: e.target.value })}
+        />
+      </Field>
+
+      {block.variant === "quote" && (
+        <Field label="Attribution (optional)">
+          <input
+            type="text"
+            value={block.attribution ?? ""}
+            placeholder="e.g. Jane Doe, CTO"
+            onChange={(e) => onChange({ ...block, attribution: e.target.value })}
+          />
+        </Field>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Call to action
+// ---------------------------------------------------------------------------
+
+export function CtaForm({
+  block,
+  onChange
+}: {
+  block: CtaBlock;
+  onChange: (b: CtaBlock) => void;
+}) {
+  const invalidHref = block.href.trim() !== "" && !isSafeUrl(block.href);
+  return (
+    <div className={styles.form}>
+      <Field label="Heading (optional)">
+        <input
+          type="text"
+          value={block.heading ?? ""}
+          placeholder="e.g. Explore the source"
+          onChange={(e) => onChange({ ...block, heading: e.target.value })}
+        />
+      </Field>
+
+      <Field label="Text (optional)">
+        <input
+          type="text"
+          value={block.text ?? ""}
+          placeholder="e.g. Vulkan Renderer is open source and built with CMake."
+          onChange={(e) => onChange({ ...block, text: e.target.value })}
+        />
+      </Field>
+
+      <Field label="Button label (required)">
+        <input
+          type="text"
+          value={block.label}
+          placeholder="e.g. View on GitHub"
+          onChange={(e) => onChange({ ...block, label: e.target.value })}
+        />
+      </Field>
+
+      <Field label="Button link (required)">
+        <input
+          type="text"
+          value={block.href}
+          placeholder="https://… or /path"
+          aria-invalid={invalidHref}
+          onChange={(e) => onChange({ ...block, href: e.target.value })}
+        />
+      </Field>
+    </div>
+  );
+}

--- a/src/components/ProjectBlocks/editor/ProjectPageEditor.module.scss
+++ b/src/components/ProjectBlocks/editor/ProjectPageEditor.module.scss
@@ -1,0 +1,442 @@
+@use "@/styles/reorder" as r;
+
+.editorRoot {
+  width: 100%;
+  max-width: 1100px;
+  margin-inline: auto;
+}
+
+.statusBar {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-bottom: 1.25rem;
+  min-height: 2.25rem;
+}
+
+.statusText {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.statusError {
+  color: var(--error-text);
+  font-size: 0.9rem;
+}
+
+.empty {
+  text-align: center;
+  color: var(--text-muted);
+  background-color: var(--bg-secondary);
+  border: 1px dashed var(--border-color);
+  border-radius: var(--radius-md);
+  padding: 2rem 1.5rem;
+}
+
+// --- Block list --------------------------------------------------------------
+
+.blockList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.blockItem {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background-color: var(--bg-card);
+  overflow: hidden;
+}
+
+.floating {
+  @include r.floating-layer;
+  @include r.floating-card;
+}
+
+.blockBar {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  padding: 0.5rem 0.75rem;
+  background-color: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.dragHandle {
+  @include r.drag-handle;
+}
+
+.blockTag {
+  font-size: 0.8rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-secondary);
+}
+
+.blockBarActions {
+  margin-left: auto;
+  display: flex;
+  gap: 0.4rem;
+}
+
+.iconBtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.25rem;
+  height: 2.25rem;
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  background-color: var(--bg-card);
+  color: var(--text-secondary);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+  }
+
+  &:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+}
+
+.blockPreview {
+  padding: 1.25rem;
+
+  // Neutralize the visitor wrapper's vertical rhythm inside a single-block preview.
+  :global(.blocks) {
+    gap: 0;
+  }
+}
+
+// --- Edit panel --------------------------------------------------------------
+
+.editPanel {
+  padding: 1.25rem;
+}
+
+.form {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.fieldLabel {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.field input[type="text"],
+.field textarea,
+.field select,
+.row input,
+.statRow input,
+.actionRow input,
+.galleryEditFields input {
+  width: 100%;
+  padding: 0.5rem 0.65rem;
+  font: inherit;
+  color: var(--text-primary);
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+
+  &[aria-invalid="true"] {
+    border-color: var(--error-border);
+  }
+}
+
+.subgroup {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.85rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+
+  legend {
+    font-size: 0.8rem;
+    font-weight: 600;
+    color: var(--text-muted);
+    padding-inline: 0.35rem;
+  }
+}
+
+.row,
+.actionRow,
+.statRow,
+.galleryEditRow,
+.featureEditRow {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.featureEditRow {
+  align-items: flex-start;
+}
+
+.featureEditFields {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.featureEditFields input,
+.featureEditFields textarea {
+  width: 100%;
+  padding: 0.5rem 0.65rem;
+  font: inherit;
+  color: var(--text-primary);
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+
+  &:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+}
+
+.statRow,
+.actionRow {
+  flex-wrap: wrap;
+
+  input {
+    flex: 1 1 8rem;
+    min-width: 0;
+  }
+}
+
+.galleryEditRow {
+  align-items: flex-start;
+}
+
+.galleryEditFields {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  min-width: 0;
+}
+
+.galleryEditActions {
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.3rem;
+}
+
+.imagePreviewRow {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.imagePreview {
+  width: 96px;
+  height: 64px;
+  object-fit: cover;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border-color);
+  flex-shrink: 0;
+}
+
+.chipList {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.editChip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  background-color: var(--bg-secondary);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  padding: 0.25rem 0.5rem;
+
+  button {
+    border: none;
+    background: none;
+    cursor: pointer;
+    color: var(--text-muted);
+    font-size: 1.1rem;
+    line-height: 1;
+    padding: 0;
+
+    &:hover {
+      color: var(--error-text);
+    }
+  }
+}
+
+.addRowBtn,
+.secondaryBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  align-self: flex-start;
+  padding: 0.45rem 0.8rem;
+  font: inherit;
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+
+  &:hover {
+    color: var(--text-primary);
+    border-color: var(--text-muted);
+  }
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+.editActions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.6rem;
+  margin-top: 1.25rem;
+}
+
+.cancelBtn,
+.saveBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  min-height: 44px;
+  padding: 0.5rem 1.1rem;
+  font: inherit;
+  font-weight: 600;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+}
+
+.cancelBtn {
+  background-color: var(--bg-card);
+  color: var(--text-secondary);
+  border: 1px solid var(--border-color);
+}
+
+.saveBtn {
+  background-color: var(--accent);
+  color: var(--text-on-accent);
+  border: 1px solid transparent;
+
+  &:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
+  }
+}
+
+// --- Add block palette -------------------------------------------------------
+
+.addZone {
+  margin-top: 1.5rem;
+}
+
+.addBlockBtn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+  justify-content: center;
+  min-height: 48px;
+  padding: 0.75rem 1rem;
+  font: inherit;
+  font-weight: 600;
+  color: var(--accent-text);
+  background-color: var(--bg-card);
+  border: 1px dashed var(--border-color);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--accent);
+  }
+}
+
+.palette {
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-md);
+  background-color: var(--bg-card);
+  box-shadow: var(--shadow-md);
+  overflow: hidden;
+}
+
+.paletteHead {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0.6rem 0.85rem;
+  font-weight: 600;
+  background-color: var(--bg-secondary);
+  border-bottom: 1px solid var(--border-color);
+}
+
+.paletteList {
+  list-style: none;
+  padding: 0.5rem;
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+  gap: 0.5rem;
+}
+
+.paletteItem {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  width: 100%;
+  text-align: left;
+  padding: 0.7rem 0.85rem;
+  background-color: var(--bg-card);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+
+  &:hover {
+    border-color: var(--accent);
+    background-color: var(--bg-secondary);
+  }
+}
+
+.paletteItemName {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.paletteItemDesc {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+}

--- a/src/components/ProjectBlocks/editor/ProjectPageEditor.tsx
+++ b/src/components/ProjectBlocks/editor/ProjectPageEditor.tsx
@@ -1,0 +1,361 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faGripVertical,
+  faPen,
+  faTrash,
+  faPlus,
+  faCheck,
+  faXmark,
+  faEye,
+  faEyeSlash
+} from "@fortawesome/free-solid-svg-icons";
+import RichTextEditor from "@/components/RichTextEditor/RichTextEditor";
+import { updateProjectPage } from "@/app/admin/contentActions";
+import { useDragReorder } from "@/components/useDragReorder";
+import ProjectBlocks from "../ProjectBlocks";
+import {
+  createBlock,
+  BLOCK_LABELS,
+  BLOCK_DESCRIPTIONS,
+  type Block,
+  type BlockType,
+  type RichTextBlock
+} from "../blocks";
+import {
+  HeroForm,
+  FeatureGridForm,
+  StatsForm,
+  TechStackForm,
+  GalleryForm,
+  VideoForm,
+  CalloutForm,
+  CtaForm,
+  isBlockComplete
+} from "./BlockForms";
+import styles from "./ProjectPageEditor.module.scss";
+
+const BLOCK_ORDER: BlockType[] = [
+  "hero",
+  "richText",
+  "featureGrid",
+  "stats",
+  "techStack",
+  "gallery",
+  "video",
+  "callout",
+  "cta"
+];
+
+type Props = {
+  projectId: string;
+  projectTitle: string;
+  initialBlocks: Block[];
+};
+
+/**
+ * Admin authoring surface for a project's case-study blocks. Editors add blocks
+ * from a curated palette, reorder them (pointer + keyboard, via useDragReorder),
+ * and edit each block in a purpose-built form. Structural changes (add/reorder/
+ * delete) and committed edits persist through `updateProjectPage`, which returns
+ * the sanitized list we then adopt — so the editor always reflects exactly what's
+ * stored. Because the preview reuses the visitor renderer, this surface *is* the
+ * preview.
+ */
+export default function ProjectPageEditor({ projectId, projectTitle, initialBlocks }: Props) {
+  const [blocks, setBlocks] = useState<Block[]>(initialBlocks);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<Block | null>(null);
+  const [isNew, setIsNew] = useState(false);
+  const [paletteOpen, setPaletteOpen] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+  const [status, setStatus] = useState("");
+  const [previewMode, setPreviewMode] = useState(false);
+
+  const blocksRef = useRef(blocks);
+  useEffect(() => {
+    blocksRef.current = blocks;
+  }, [blocks]);
+
+  async function persist(next: Block[]): Promise<{ ok: true } | { ok: false; error: string }> {
+    setBlocks(next);
+    setSaving(true);
+    setError("");
+    setStatus("");
+    const result = await updateProjectPage(projectId, next);
+    setSaving(false);
+    if ("error" in result) {
+      setError(result.error);
+      return { ok: false, error: result.error };
+    }
+    // Adopt the sanitized server copy so local state can't drift from storage.
+    setBlocks(result.blocks);
+    setStatus("Saved");
+    return { ok: true };
+  }
+
+  const drag = useDragReorder<Block>({
+    items: blocks,
+    setItems: setBlocks,
+    getKey: (b) => b.id,
+    onCommit: (orderedKeys) => {
+      const byId = new Map(blocksRef.current.map((b) => [b.id, b]));
+      const ordered = orderedKeys.map((k) => byId.get(k)).filter(Boolean) as Block[];
+      void persist(ordered);
+    }
+  });
+
+  function addBlock(type: BlockType) {
+    setPaletteOpen(false);
+    const block = createBlock(type, projectTitle);
+    setBlocks((prev) => [...prev, block]);
+    setEditingId(block.id);
+    setDraft(structuredClone(block));
+    setIsNew(true);
+    setError("");
+    setStatus("");
+  }
+
+  function startEdit(block: Block) {
+    setEditingId(block.id);
+    setDraft(structuredClone(block));
+    setIsNew(false);
+    setError("");
+    setStatus("");
+  }
+
+  function cancelEdit() {
+    if (isNew && editingId) {
+      // Discard a never-saved block entirely.
+      setBlocks((prev) => prev.filter((b) => b.id !== editingId));
+    }
+    setEditingId(null);
+    setDraft(null);
+    setIsNew(false);
+  }
+
+  async function commitEdit() {
+    if (!draft) return;
+    if (!isBlockComplete(draft)) {
+      setError("Please complete the required fields before saving this block.");
+      return;
+    }
+    const next = blocksRef.current.map((b) => (b.id === draft.id ? draft : b));
+    const result = await persist(next);
+    if (!("error" in result)) {
+      setEditingId(null);
+      setDraft(null);
+      setIsNew(false);
+    }
+  }
+
+  async function deleteBlock(id: string) {
+    if (!window.confirm("Delete this block? This can't be undone.")) return;
+    if (editingId === id) cancelEdit();
+    await persist(blocksRef.current.filter((b) => b.id !== id));
+  }
+
+  // Save handler the rich-text editor expects ({ ok } | { error }).
+  async function saveRichText(block: RichTextBlock, content: { children: any[] }) {
+    const nextBlock: RichTextBlock = { ...block, content };
+    const next = blocksRef.current.map((b) => (b.id === block.id ? nextBlock : b));
+    const result = await persist(next);
+    if ("error" in result) return { error: result.error };
+    setEditingId(null);
+    setDraft(null);
+    setIsNew(false);
+    return { ok: true } as const;
+  }
+
+  function renderForm(block: Block) {
+    switch (block.type) {
+      case "hero":
+        return <HeroForm block={block} onChange={setDraft} />;
+      case "featureGrid":
+        return <FeatureGridForm block={block} onChange={setDraft} />;
+      case "stats":
+        return <StatsForm block={block} onChange={setDraft} />;
+      case "techStack":
+        return <TechStackForm block={block} onChange={setDraft} />;
+      case "gallery":
+        return <GalleryForm block={block} onChange={setDraft} />;
+      case "video":
+        return <VideoForm block={block} onChange={setDraft} />;
+      case "callout":
+        return <CalloutForm block={block} onChange={setDraft} />;
+      case "cta":
+        return <CtaForm block={block} onChange={setDraft} />;
+      default:
+        return null;
+    }
+  }
+
+  if (previewMode) {
+    return (
+      <div className={styles.editorRoot}>
+        <div className={styles.statusBar}>
+          <button
+            type="button"
+            className={styles.secondaryBtn}
+            onClick={() => setPreviewMode(false)}
+          >
+            <FontAwesomeIcon icon={faEyeSlash} /> Exit preview
+          </button>
+        </div>
+        {blocks.length === 0 ? (
+          <p className={styles.empty}>No blocks yet.</p>
+        ) : (
+          <ProjectBlocks blocks={blocks} />
+        )}
+      </div>
+    );
+  }
+
+  return (
+    <div className={styles.editorRoot}>
+      <div className={styles.statusBar}>
+        <span className={styles.statusText} role="status" aria-live="polite">
+          {saving ? "Saving…" : error ? "" : status}
+        </span>
+        {error && (
+          <span className={styles.statusError} role="alert">
+            {error}
+          </span>
+        )}
+        <button
+          type="button"
+          className={styles.secondaryBtn}
+          onClick={() => setPreviewMode(true)}
+          disabled={blocks.length === 0}
+        >
+          <FontAwesomeIcon icon={faEye} /> Preview
+        </button>
+      </div>
+
+      {/* Live region for keyboard reordering announcements. */}
+      <div className="srOnly" role="status" aria-live="polite">
+        {drag.announcement}
+      </div>
+
+      {blocks.length === 0 && (
+        <p className={styles.empty}>
+          This project has no content blocks yet. Add your first block to get started.
+        </p>
+      )}
+
+      <ul className={styles.blockList}>
+        {blocks.map((block, index) => {
+          const editing = editingId === block.id;
+          const shown = editing && draft ? draft : block;
+          const floating = drag.draggingKey === block.id;
+
+          return (
+            <li
+              key={block.id}
+              ref={drag.registerCard(block.id)}
+              className={`${styles.blockItem} ${floating ? styles.floating : ""}`}
+              style={floating ? drag.floatingStyle : undefined}
+            >
+              <div className={styles.blockBar}>
+                <button
+                  type="button"
+                  className={styles.dragHandle}
+                  aria-label={`Reorder ${BLOCK_LABELS[block.type]} block. Press arrow keys to move, or drag.`}
+                  onPointerDown={(e) => drag.startDrag(index, block.id, e)}
+                  onKeyDown={drag.keyboardReorder(block.id)}
+                >
+                  <FontAwesomeIcon icon={faGripVertical} />
+                </button>
+                <span className={styles.blockTag}>{BLOCK_LABELS[block.type]}</span>
+                <div className={styles.blockBarActions}>
+                  {!editing && (
+                    <button
+                      type="button"
+                      className={styles.iconBtn}
+                      aria-label={`Edit ${BLOCK_LABELS[block.type]} block`}
+                      onClick={() => startEdit(block)}
+                    >
+                      <FontAwesomeIcon icon={faPen} />
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className={styles.iconBtn}
+                    aria-label={`Delete ${BLOCK_LABELS[block.type]} block`}
+                    onClick={() => deleteBlock(block.id)}
+                  >
+                    <FontAwesomeIcon icon={faTrash} />
+                  </button>
+                </div>
+              </div>
+
+              {editing && block.type === "richText" ? (
+                <RichTextEditor
+                  initialContent={(shown as RichTextBlock).content}
+                  onSave={(content) => saveRichText(block as RichTextBlock, content)}
+                  onCancel={cancelEdit}
+                />
+              ) : editing ? (
+                <div className={styles.editPanel}>
+                  {renderForm(draft as Block)}
+                  <div className={styles.editActions}>
+                    <button type="button" className={styles.cancelBtn} onClick={cancelEdit} disabled={saving}>
+                      <FontAwesomeIcon icon={faXmark} /> Cancel
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.saveBtn}
+                      onClick={commitEdit}
+                      disabled={saving || !isBlockComplete(draft)}
+                    >
+                      <FontAwesomeIcon icon={faCheck} /> {saving ? "Saving…" : "Save block"}
+                    </button>
+                  </div>
+                </div>
+              ) : (
+                <div className={styles.blockPreview}>
+                  <ProjectBlocks blocks={[shown]} />
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+
+      <div className={styles.addZone}>
+        {paletteOpen ? (
+          <div className={styles.palette} role="menu" aria-label="Add a content block">
+            <div className={styles.paletteHead}>
+              <span>Add a block</span>
+              <button
+                type="button"
+                className={styles.iconBtn}
+                aria-label="Close block menu"
+                onClick={() => setPaletteOpen(false)}
+              >
+                <FontAwesomeIcon icon={faXmark} />
+              </button>
+            </div>
+            <ul className={styles.paletteList}>
+              {BLOCK_ORDER.map((type) => (
+                <li key={type}>
+                  <button type="button" className={styles.paletteItem} onClick={() => addBlock(type)} role="menuitem">
+                    <span className={styles.paletteItemName}>{BLOCK_LABELS[type]}</span>
+                    <span className={styles.paletteItemDesc}>{BLOCK_DESCRIPTIONS[type]}</span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : (
+          <button type="button" className={styles.addBlockBtn} onClick={() => setPaletteOpen(true)}>
+            <FontAwesomeIcon icon={faPlus} /> Add block
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RichTextEditor/AssetPicker.tsx
+++ b/src/components/RichTextEditor/AssetPicker.tsx
@@ -15,15 +15,23 @@ type Props = {
   onClose: () => void;
   /** Dialog heading; defaults to the rich-text "Insert image" context. */
   title?: string;
+  /** Which media kind to list/pick. Videos can't be uploaded here (the uploader
+   *  only crops images), so the upload control is hidden in video mode. */
+  accept?: "image" | "video";
 };
 
 /**
- * Inline image picker. Loads assets through the same Media Library data layer
- * (via the `listMediaAssets` action), narrows to images, and lets the admin
- * search + pick one without leaving the page. Used by the rich-text editor and
- * the project image control.
+ * Inline media picker. Loads assets through the same Media Library data layer
+ * (via the `listMediaAssets` action), narrows to the requested kind, and lets the
+ * admin search + pick one without leaving the page. Used by the rich-text editor,
+ * the project image control, and the block editor's image/video pickers.
  */
-export default function AssetPicker({ onSelect, onClose, title = "Insert image" }: Props) {
+export default function AssetPicker({
+  onSelect,
+  onClose,
+  title = "Insert image",
+  accept = "image"
+}: Props) {
   const [assets, setAssets] = useState<MediaAsset[] | null>(null);
   const [error, setError] = useState("");
   const [query, setQuery] = useState("");
@@ -47,11 +55,12 @@ export default function AssetPicker({ onSelect, onClose, title = "Insert image" 
   }, []);
 
   const images = useMemo(() => {
-    const list = (assets ?? []).filter((a) => (a.mimeType ?? "").startsWith("image/"));
+    const prefix = accept === "video" ? "video/" : "image/";
+    const list = (assets ?? []).filter((a) => (a.mimeType ?? "").startsWith(prefix));
     const q = query.trim().toLowerCase();
     if (!q) return list;
     return list.filter((a) => `${a.title ?? ""} ${a.fileName}`.toLowerCase().includes(q));
-  }, [assets, query]);
+  }, [assets, query, accept]);
 
   return (
     <Modal onClose={onClose} labelledBy={titleId} overlayClassName={styles.pickerOverlay}>
@@ -60,8 +69,9 @@ export default function AssetPicker({ onSelect, onClose, title = "Insert image" 
           <h2 className={styles.pickerTitle} id={titleId}>{title}</h2>
           <div className={styles.pickerHeadActions}>
             {/* Reuse the Media Library's crop & upload widget — a freshly
-                uploaded asset is inserted straight into the editor. */}
-            <MediaUploader onUploaded={onSelect} />
+                uploaded asset is inserted straight into the editor. Images only;
+                videos are picked from existing library assets. */}
+            {accept === "image" && <MediaUploader onUploaded={onSelect} />}
             <button
               type="button"
               className={styles.pickerClose}
@@ -79,8 +89,8 @@ export default function AssetPicker({ onSelect, onClose, title = "Insert image" 
             type="search"
             value={query}
             onChange={(e) => setQuery(e.target.value)}
-            placeholder="Search images by name…"
-            aria-label="Search images by name"
+            placeholder={`Search ${accept === "video" ? "videos" : "images"} by name…`}
+            aria-label={`Search ${accept === "video" ? "videos" : "images"} by name`}
             autoFocus
           />
         </div>
@@ -93,7 +103,9 @@ export default function AssetPicker({ onSelect, onClose, title = "Insert image" 
           <p className={styles.pickerState} role="status" aria-live="polite">Loading media…</p>
         ) : images.length === 0 ? (
           <p className={styles.pickerState}>
-            {query.trim() ? "No images match your search." : "No images in the library yet."}
+            {query.trim()
+              ? `No ${accept === "video" ? "videos" : "images"} match your search.`
+              : `No ${accept === "video" ? "videos" : "images"} in the library yet.`}
           </p>
         ) : (
           <ul className={styles.pickerGrid}>
@@ -108,13 +120,24 @@ export default function AssetPicker({ onSelect, onClose, title = "Insert image" 
                     title={name}
                   >
                     <span className={styles.pickerThumb}>
-                      <Image
-                        src={asset.url}
-                        alt={name}
-                        fill
-                        sizes="160px"
-                        className={styles.pickerImg}
-                      />
+                      {accept === "video" ? (
+                        // eslint-disable-next-line jsx-a11y/media-has-caption
+                        <video
+                          src={asset.url}
+                          muted
+                          preload="metadata"
+                          className={styles.pickerImg}
+                          style={{ width: "100%", height: "100%", objectFit: "cover" }}
+                        />
+                      ) : (
+                        <Image
+                          src={asset.url}
+                          alt={name}
+                          fill
+                          sizes="160px"
+                          className={styles.pickerImg}
+                        />
+                      )}
                       {asset.status === "draft" && (
                         <span className={styles.pickerBadge}>Draft</span>
                       )}

--- a/src/components/RichTextEditor/EditableRichText.tsx
+++ b/src/components/RichTextEditor/EditableRichText.tsx
@@ -9,9 +9,9 @@ import RichTextEditor from "./RichTextEditor";
 import styles from "./RichTextEditor.module.scss";
 
 type Props = {
-  model: string; // Hygraph model API ID (e.g. "Project")
+  model: string; // Hygraph model API ID (e.g. "RichTextWidget")
   id: string; // entry id
-  field: string; // RichText field API ID (e.g. "projectPageContent")
+  field: string; // RichText field API ID (e.g. "content")
   value: any; // raw rich-text AST ({ children })
 };
 

--- a/src/components/RichTextField.tsx
+++ b/src/components/RichTextField.tsx
@@ -2,9 +2,9 @@ import RichTextWidget from "@/components/RichTextWidget";
 import EditableRichText from "@/components/RichTextEditor";
 
 type Props = {
-  model: string; // Hygraph model API ID (e.g. "Project")
+  model: string; // Hygraph model API ID (e.g. "RichTextWidget")
   id: string; // entry id
-  field: string; // RichText field API ID (e.g. "projectPageContent")
+  field: string; // RichText field API ID (e.g. "content")
   raw: any; // raw rich-text AST ({ children })
   isAdmin: boolean;
 };

--- a/src/components/RichTextWidget/RichText.module.scss
+++ b/src/components/RichTextWidget/RichText.module.scss
@@ -1,122 +1,185 @@
+$mono: ui-monospace, "Cascadia Code", "JetBrains Mono", "Source Code Pro", Menlo, Consolas, monospace;
 
+// Typography only — shared by the boxed "card" variant (About page) and the
+// "bare" variant used inside project case-study blocks.
 .container {
-  background-color: var(--bg-card);
-  line-height: 1.7;
-  font-size: 1.05rem;
-  color: var(--text-primary);
-  max-width: 760px;
+  line-height: 1.75;
+  font-size: 1.06rem;
+  color: var(--text-secondary);
+  max-width: 720px;
   margin-inline: auto;
-  padding: clamp(1.75rem, 4vw, 3rem) clamp(1.5rem, 4vw, 2.75rem);
-  border-radius: var(--radius-md);
-  border: 1px solid var(--border-color);
-  box-shadow: var(--shadow-sm);
 
   & > * {
     max-width: 100%;
     height: auto;
   }
 
-  h2, h3, h4, h5, h6 {
-    font-weight: 600;
-    line-height: 1.3;
-    margin-top: 2rem;
-    margin-bottom: 0.65rem;
-    color: var(--text-primary);
+  & > *:first-child {
+    margin-top: 0;
+  }
 
-    &:first-child {
+  h2, h3, h4, h5, h6 {
+    font-family: var(--font-display), var(--font-body), sans-serif;
+    line-height: 1.2;
+    letter-spacing: -0.02em;
+    color: var(--text-primary);
+  }
+
+  // Section-level heading: a short accent rule above sets each section apart and
+  // matches the standalone block headings, so prose and blocks read as one page.
+  h2 {
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    margin-top: 3rem;
+    margin-bottom: 1rem;
+
+    &::before {
+      content: "";
+      display: block;
+      width: 2.25rem;
+      height: 3px;
+      margin-bottom: 0.9rem;
+      border-radius: 2px;
+      background: linear-gradient(90deg, var(--accent), transparent);
+    }
+
+    &:first-child::before {
       margin-top: 0;
     }
   }
 
-  h1 {
-    font-size: 1.9rem;
-    margin-top: 1rem;
+  h3 {
+    font-size: 1.3rem;
+    margin-top: 2rem;
+    margin-bottom: 0.6rem;
   }
 
-  h2 {
-    font-size: 1.6rem;
-    color: var(--accent-secondary);
-    margin-top: 1rem;
+  h4 {
+    font-size: 1.1rem;
+    margin-top: 1.75rem;
+    margin-bottom: 0.5rem;
   }
 
-  h3 { font-size: 1.3rem; }
-  h4 { font-size: 1.15rem; }
-  h5 { font-size: 1rem; text-transform: uppercase; letter-spacing: 0.04em; }
-  h6 { font-size: 0.9rem; color: var(--text-muted); }
+  h5 {
+    font-family: $mono;
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--accent-text);
+    margin-top: 1.75rem;
+    margin-bottom: 0.5rem;
+  }
+
+  h6 {
+    font-size: 0.9rem;
+    color: var(--text-muted);
+    margin-top: 1.5rem;
+    margin-bottom: 0.5rem;
+  }
 
   p {
-    margin-bottom: 1rem;
+    margin-bottom: 1.1rem;
 
     &:last-child {
       margin-bottom: 0;
     }
   }
 
-  code {
-    font-family: monospace;
-    font-size: 0.9em;
-    background-color: var(--bg-secondary);
-    padding: 0.1rem 0.35rem;
-    border-radius: 4px;
+  strong {
+    color: var(--text-primary);
+    font-weight: 600;
   }
 
-  pre {
-    margin-block: 1rem;
-    padding: 0.85rem 1rem;
-    background-color: var(--bg-secondary);
-    border: 1px solid var(--border-color);
-    border-radius: 6px;
-    font-family: monospace;
-    font-size: 0.9rem;
-    white-space: pre-wrap;
-    overflow-x: auto;
-
-    code {
-      background: none;
-      padding: 0;
-    }
-  }
-
+  // Custom technical list markers: a small emerald diamond for bullets, a
+  // monospace accent counter for ordered lists.
   ul, ol {
-    margin-bottom: 0.75rem;
-    padding-left: 1.5rem;
-
-    @media (min-width: 768px) {
-      padding-left: 2rem;
-    }
-
-    li {
-      margin-bottom: 0.25rem;
-
-      &:last-child {
-        margin-bottom: 0;
-      }
-
-      ul, ol {
-        margin: 0.5rem 0;
-      }
-    }
+    margin-bottom: 1.1rem;
+    padding-left: 1.6rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
   }
 
   ul {
-    list-style-type: disc;
+    list-style: none;
 
-    ul {
-      list-style-type: circle;
+    & > li {
+      position: relative;
+      padding-left: 1.5rem;
 
-      ul {
-        list-style-type: square;
+      &::before {
+        content: "";
+        position: absolute;
+        left: 0;
+        top: 0.62em;
+        width: 0.45rem;
+        height: 0.45rem;
+        border-radius: 1px;
+        transform: rotate(45deg);
+        background-color: var(--accent);
       }
+    }
+  }
+
+  ol {
+    list-style: decimal;
+
+    & > li::marker {
+      font-family: $mono;
+      font-weight: 600;
+      color: var(--accent-text);
+    }
+  }
+
+  li {
+    ul, ol {
+      margin: 0.5rem 0 0;
+    }
+  }
+
+  code {
+    font-family: $mono;
+    font-size: 0.88em;
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    padding: 0.1rem 0.4rem;
+    border-radius: 4px;
+    color: var(--accent-text);
+  }
+
+  pre {
+    margin-block: 1.5rem;
+    padding: 1.1rem 1.25rem;
+    background-color: var(--bg-secondary);
+    border: 1px solid var(--border-color);
+    border-left: 3px solid var(--accent);
+    border-radius: var(--radius-sm);
+    font-family: $mono;
+    font-size: 0.88rem;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    overflow-x: auto;
+    color: var(--text-primary);
+
+    code {
+      background: none;
+      border: none;
+      padding: 0;
+      color: inherit;
     }
   }
 
   blockquote {
-    margin-block: 1rem;
-    padding: 0.75rem 1rem;
-    background-color: var(--bg-secondary);
+    margin-block: 1.5rem;
+    padding: 0.5rem 0 0.5rem 1.25rem;
     border-left: 3px solid var(--accent);
     color: var(--text-primary);
-    border-radius: 4px;
+    font-size: 1.1rem;
+    font-style: italic;
+  }
+
+  img {
+    border-radius: var(--radius-md);
+    border: 1px solid var(--border-color);
   }
 
   a {
@@ -124,7 +187,7 @@
     text-decoration: none;
     position: relative;
     font-weight: 500;
-    transition: all 0.3s ease-in-out;
+    transition: color 0.3s ease-in-out;
 
     &::after {
       content: '';
@@ -144,5 +207,22 @@
         width: 100%;
       }
     }
+  }
+}
+
+// The standalone bordered surface (About page).
+.card {
+  background-color: var(--bg-card);
+  color: var(--text-primary);
+  padding: clamp(1.75rem, 4vw, 3rem) clamp(1.5rem, 4vw, 2.75rem);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border-color);
+  box-shadow: var(--shadow-sm);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .container a,
+  .container a::after {
+    transition: none;
   }
 }

--- a/src/components/RichTextWidget/RichTextWidget.tsx
+++ b/src/components/RichTextWidget/RichTextWidget.tsx
@@ -14,9 +14,19 @@ const renderers = {
   table_header_cell: ({ children }: any) => <th scope="col">{children}</th>
 };
 
-export default function RichTextWidget({ content }: { content: any }) {
+type Props = {
+  content: any;
+  /**
+   * "card" (default) wraps the prose in the standalone bordered surface used on
+   * the About page. "bare" drops the box so the prose sits inside a larger
+   * composition (project case-study blocks) without looking like a widget.
+   */
+  variant?: "card" | "bare";
+};
+
+export default function RichTextWidget({ content, variant = "card" }: Props) {
   return (
-    <div className={richTextStyles.container}>
+    <div className={`${richTextStyles.container} ${variant === "card" ? richTextStyles.card : ""}`}>
       <RichText content={content} renderers={renderers} />
     </div>
   );


### PR DESCRIPTION
This pull request introduces a new, extensible block-based system for project case study pages, replacing the previous single rich-text field with a flexible JSON-based `projectPage` field. The change enables richer layouts, more interactive content, and improved accessibility. It also adds a new admin editor for managing these blocks, and implements several new presentational block components.

The most important changes are:

**Block-based case study system:**

* Replaces the old `projectPageContent` rich-text field with a new `projectPage` JSON field for storing an ordered list of content blocks, allowing for more flexible and structured project pages. The backend and frontend are updated to use and sanitize this new field. ([src/app/admin/contentActions.tsL25](diffhunk://#diff-4907ce1515ed765eab47dbd285af48dc599d8c5b6b266a0b103395a09f504bcbL25), [src/app/projects/[slug]/page.tsxL20-R22](diffhunk://#diff-1d2a210291c84a2d68494da2260754887ddacc859763a29c124230fa22f487bbL20-R22), [src/app/projects/[slug]/page.tsxR74-R77](diffhunk://#diff-1d2a210291c84a2d68494da2260754887ddacc859763a29c124230fa22f487bbR74-R77), [src/app/projects/[slug]/page.tsxL83-R95](diffhunk://#diff-1d2a210291c84a2d68494da2260754887ddacc859763a29c124230fa22f487bbL83-R95))
* Adds a new API (`updateProjectPage`) for saving and sanitizing the block list, ensuring only valid blocks and safe content are persisted.

**Admin/editor improvements:**

* Integrates a new `ProjectPageEditor` for admins, allowing them to add, edit, and reorder blocks on project pages with immediate feedback. The editor uses the new block API and adopts the sanitized result after saving. ([src/app/projects/[slug]/page.tsxL83-R95](diffhunk://#diff-1d2a210291c84a2d68494da2260754887ddacc859763a29c124230fa22f487bbL83-R95))

**New presentational blocks:**

* Implements several new block components for project pages:
  - [`Hero`](diffhunk://#diff-fc37ea9ee7726b27c2fcaeb5b57ff30d115bba45db1f51513fcb5c05baa2c1eaR1-R86): Prominent project summary with headline, facts, and actions.
  - [`Callout`](diffhunk://#diff-0ffbc36d935032e969eacadc375aaaac52321266b5cf69111d29afd20e12be58R1-R53): Highlighted notes, quotes, or status messages with icons and accessible labels.
  - [`FeatureGrid`](diffhunk://#diff-431f73b392d8a1cab483c2a0349c5d5f436d94975f93023734407d3d13831a9cR1-R31): Responsive grid for listing features or capabilities.
  - [`Gallery`](diffhunk://#diff-a12c02e6e9801484bf26066297f79d6eba71d88999c8b728b5e58eb50784ab17R1-R129): Image gallery with lightbox modal and keyboard navigation.
  - [`Cta`](diffhunk://#diff-51d2cffd3d62f77a359d0663893a9683d08cd5092b21485847543ca678f59d86R1-R38): Call-to-action panel with styled button and external link handling.

**Cleanup and migration:**

* Removes the old rich-text field (`projectPageContent`) from project creation and editing flows, fully migrating to the new block-based approach. [[1]](diffhunk://#diff-4907ce1515ed765eab47dbd285af48dc599d8c5b6b266a0b103395a09f504bcbL451-L455) [[2]](diffhunk://#diff-4907ce1515ed765eab47dbd285af48dc599d8c5b6b266a0b103395a09f504bcbL493)

These changes together provide a more powerful, accessible, and maintainable way to build rich project case study pages.