### PR TITLE
Implement unified scroll-reveal system and refactor project animations

### DIFF
--- a/src/app/(index)/FeaturedProjects.tsx
+++ b/src/app/(index)/FeaturedProjects.tsx
@@ -8,12 +8,18 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faStar, faGripVertical } from "@fortawesome/free-solid-svg-icons";
 import EditableText from "@/components/EditableText";
 import { useDragReorder } from "@/components/useDragReorder";
+import { useReveal } from "@/components/useReveal";
 import { useTilt } from "@/components/useTilt";
 import { useSiteConfig } from "@/components/useSiteConfig";
 import { projectFlags } from "@/lib/siteConfig";
 
-function FeaturedCard({ project, isAdmin, innerRef, onHandlePointerDown, onHandleKeyDown, onUnfeature, floating }: any) {
+function FeaturedCard({ project, isAdmin, innerRef, onHandlePointerDown, onHandleKeyDown, onUnfeature, floating, revealIndex }: any) {
   const tilt = useTilt();
+  // Each visitor card observes itself, so it reveals exactly as it scrolls into
+  // view (a single container observer would leave on-screen cards hidden until
+  // the whole grid crossed the threshold). The full index drives a first-to-last
+  // cascade when the grid enters the viewport together.
+  const reveal = useReveal<HTMLDivElement>();
   const thumbnail = (
     <div className={styles.thumbnail}>
       {project.image && (
@@ -72,7 +78,12 @@ function FeaturedCard({ project, isAdmin, innerRef, onHandlePointerDown, onHandl
   }
 
   return (
-    <div className={styles.card} {...tilt}>
+    <div
+      ref={reveal.ref}
+      className={`reveal ${reveal.isVisible ? "is-visible" : ""} ${styles.card}`}
+      style={{ ["--reveal-index" as any]: revealIndex ?? 0 }}
+      {...tilt}
+    >
       {thumbnail}
       <div className={styles.body}>
         <h3>{project.title}</h3>
@@ -86,6 +97,11 @@ function FeaturedCard({ project, isAdmin, innerRef, onHandlePointerDown, onHandl
 export default function FeaturedProjects({ className, projects, description, config, isAdmin = false }: any) {
   const [items, setItems] = useState<any[]>(projects);
   const { cfg, cfgRef, persist } = useSiteConfig(config);
+
+  // Header reveals on its own viewport entry; each card self-reveals (see
+  // FeaturedCard). Admin views render statically so editing never re-hides them.
+  const headerReveal = useReveal<HTMLHeadingElement>();
+  const headerVisible = isAdmin || headerReveal.isVisible;
 
   useEffect(() => setItems(projects), [projects]);
 
@@ -109,12 +125,18 @@ export default function FeaturedProjects({ className, projects, description, con
 
   return (
     <div className={className}>
-      <h2 className={styles.sectionHeader}>
+      <h2
+        ref={headerReveal.ref}
+        className={`reveal ${headerVisible ? "is-visible" : ""} ${styles.sectionHeader}`}
+      >
         <EditableText model="Description" id={description.id} field="header" value={description.header} editable={isAdmin}>
           {description.header}
         </EditableText>
       </h2>
-      <p className={styles.sectionDescription}>
+      <p
+        className={`reveal ${headerVisible ? "is-visible" : ""} ${styles.sectionDescription}`}
+        style={{ ["--reveal-index" as any]: 1 }}
+      >
         <EditableText model="Description" id={description.id} field="description" value={description.description} editable={isAdmin} multiline>
           {description.description}
         </EditableText>
@@ -137,6 +159,7 @@ export default function FeaturedProjects({ className, projects, description, con
               key={project.slug}
               project={project}
               isAdmin={isAdmin}
+              revealIndex={index}
               innerRef={drag.registerCard(project.slug)}
               onHandlePointerDown={
                 isAdmin ? (e: React.PointerEvent) => drag.startDrag(index, project.slug, e) : undefined

--- a/src/app/(index)/Portfolio.tsx
+++ b/src/app/(index)/Portfolio.tsx
@@ -6,6 +6,7 @@ import { useEffect, useId, useState } from "react";
 import EditableText from "@/components/EditableText";
 import Modal from "@/components/Modal";
 import { useDragReorder } from "@/components/useDragReorder";
+import { useReveal } from "@/components/useReveal";
 import { useSiteConfig } from "@/components/useSiteConfig";
 import {
   createPortfolioCard,
@@ -66,18 +67,28 @@ function CardView({
   onEdit,
   onToggleHide,
   onDelete,
-  floating
+  floating,
+  revealIndex
 }: any) {
   // A bad icon name renders nothing (FontAwesome warns); fall back so the slot
   // never collapses.
   const iconName = card.fontAwesomeIcon || "star";
 
+  // Each visitor card observes itself so it reveals exactly as it scrolls into
+  // view; the full index gives a first-to-last cascade when the grid enters
+  // together. Admin cards stay statically visible (and use the drag ref) so
+  // dragging/editing never re-hides them.
+  const reveal = useReveal<HTMLDivElement>();
+  const revealClass = isAdmin ? "" : `reveal ${reveal.isVisible ? "is-visible" : ""}`;
+  const rootRef = isAdmin ? innerRef : reveal.ref;
+
   return (
     <div
-      ref={innerRef}
-      className={`${styles.quickLinkCard} ${isAdmin ? styles.adminCard : ""} ${
+      ref={rootRef}
+      className={`${revealClass} ${styles.quickLinkCard} ${isAdmin ? styles.adminCard : ""} ${
         hidden ? styles.hiddenCard : ""
       } ${floating ? styles.floating : ""}`}
+      style={isAdmin ? undefined : { ["--reveal-index" as any]: revealIndex ?? 0 }}
     >
       {isAdmin && (
         <div className={styles.adminOverlay}>
@@ -237,6 +248,11 @@ function CardEditor({
 export default function Portfolio({ className, cards, description, config, isAdmin = false }: any) {
   const { cfg, cfgRef, persist } = useSiteConfig(config);
   const deleteTitleId = useId();
+
+  // Header reveals on its own viewport entry; each card self-reveals (see
+  // CardView). Admin views render statically.
+  const headerReveal = useReveal<HTMLHeadingElement>();
+  const headerVisible = isAdmin || headerReveal.isVisible;
   const [items, setItems] = useState<Card[]>(() => applyConfigToCards(cards, config, isAdmin));
   const [showCreate, setShowCreate] = useState(false);
   const [editing, setEditing] = useState<Card | null>(null);
@@ -319,12 +335,18 @@ export default function Portfolio({ className, cards, description, config, isAdm
 
   return (
     <div className={className}>
-      <h2 className={styles.sectionHeader}>
+      <h2
+        ref={headerReveal.ref}
+        className={`reveal ${headerVisible ? "is-visible" : ""} ${styles.sectionHeader}`}
+      >
         <EditableText model="Description" id={description.id} field="header" value={description.header} editable={isAdmin}>
           {description.header}
         </EditableText>
       </h2>
-      <p className={styles.sectionDescription}>
+      <p
+        className={`reveal ${headerVisible ? "is-visible" : ""} ${styles.sectionDescription}`}
+        style={{ ["--reveal-index" as any]: 1 }}
+      >
         <EditableText model="Description" id={description.id} field="description" value={description.description} editable={isAdmin} multiline>
           {description.description}
         </EditableText>
@@ -347,6 +369,7 @@ export default function Portfolio({ className, cards, description, config, isAdm
               key={card.id}
               card={card}
               isAdmin={isAdmin}
+              revealIndex={index}
               hidden={isAdmin && cardFlags(cfg, card.id).hidden}
               innerRef={drag.registerCard(card.id)}
               onHandlePointerDown={

--- a/src/app/(index)/featured.module.scss
+++ b/src/app/(index)/featured.module.scss
@@ -1,13 +1,6 @@
 @use "@/styles/variables" as *;
 @use "@/styles/reorder" as r;
 
-// Entrance animates `translate`/opacity (not `transform`) so it never collides
-// with the pointer-tilt transform applied on hover.
-@keyframes fadeInUp {
-  from { opacity: 0; translate: 0 20px; }
-  to { opacity: 1; translate: 0 0; }
-}
-
 .sectionHeader {
   font-size: var(--fs-title);
   padding-block: 0.5em;
@@ -50,13 +43,24 @@
   text-decoration: none;
 
   // `--ty` carries the hover lift inside the transform so it composes with the
-  // pointer tilt (--rx/--ry) instead of overwriting it.
+  // pointer tilt (--rx/--ry) instead of overwriting it. The scroll-reveal
+  // entrance (global `.reveal`) animates the separate `translate` property and
+  // opacity, so it never collides with this transform.
   --ty: 0px;
   transform: perspective(900px) rotateX(var(--rx, 0deg)) rotateY(var(--ry, 0deg)) translateY(var(--ty));
-  transition: transform 0.25s ease-out, box-shadow 0.3s ease-in-out;
-
-  opacity: 0;
-  animation: fadeInUp 0.6s ease-out forwards;
+  // One declaration so the reveal entrance (opacity/translate, staggered) and the
+  // hover feedback (transform/box-shadow, no delay) coexist — a separate `.reveal`
+  // transition shorthand would clobber this one (or vice-versa). The delay list
+  // lines up with the property list: entrance staggers, hover is immediate.
+  transition:
+    opacity var(--dur-slow) var(--ease-out),
+    translate var(--dur-slow) var(--ease-out),
+    transform var(--dur-base) var(--ease-out),
+    box-shadow var(--dur-base) var(--ease-standard);
+  transition-delay:
+    calc(var(--reveal-index, 0) * var(--reveal-stagger)),
+    calc(var(--reveal-index, 0) * var(--reveal-stagger)),
+    0s, 0s;
 
   &:hover {
     --ty: -5px;
@@ -102,7 +106,7 @@
   font-weight: bold;
   text-decoration: none;
   border-radius: var(--radius-sm);
-  transition: transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out, background-color 0.2s ease-in-out;
+  transition: transform var(--dur-base) ease-in-out, box-shadow var(--dur-base) ease-in-out, background-color var(--dur-fast) ease-in-out;
 }
 
 // Hover/focus feedback on the button itself, now that it's the only link in the
@@ -119,10 +123,10 @@
 }
 
 .floating {
-  // Cancel the entrance animation, whose filled transform would otherwise
-  // override the tilt below. The base .card starts at opacity 0, so restore it.
-  animation: none;
+  // Admin drag clone — kept fully opaque and untransformed by entrance state
+  // (it never carries the `.reveal` class) so it tracks the cursor cleanly.
   opacity: 1;
+  translate: none;
   @include r.floating-card;
 }
 
@@ -138,7 +142,7 @@
   width: 100%;
   height: 100%;
   object-fit: cover;
-  transition: transform 0.3s ease-in-out;
+  transition: transform var(--dur-base) ease-in-out;
 }
 
 .body {
@@ -152,7 +156,7 @@
     font-size: 1.35rem;
     color: var(--text-primary);
     margin-bottom: 0.65rem;
-    transition: color 0.3s ease-in-out;
+    transition: color var(--dur-base) ease-in-out;
   }
 
   p {

--- a/src/app/(index)/featured.module.scss
+++ b/src/app/(index)/featured.module.scss
@@ -156,7 +156,6 @@
     font-size: 1.35rem;
     color: var(--text-primary);
     margin-bottom: 0.65rem;
-    transition: color var(--dur-base) var(--ease-standard);
   }
 
   p {

--- a/src/app/(index)/featured.module.scss
+++ b/src/app/(index)/featured.module.scss
@@ -156,7 +156,7 @@
     font-size: 1.35rem;
     color: var(--text-primary);
     margin-bottom: 0.65rem;
-    transition: color var(--dur-base) ease-in-out;
+    transition: color var(--dur-base) var(--ease-standard);
   }
 
   p {

--- a/src/app/(index)/landing.module.scss
+++ b/src/app/(index)/landing.module.scss
@@ -72,7 +72,7 @@
   // layered as a transform on the wrapper, not an opacity gate, so we never
   // hide the text.
   opacity: 1;
-  animation: fadeIn 1s ease-out both;
+  animation: fadeIn 1.5s ease-out both;
 
   line-height: 1.2;
   margin-top: clamp(1rem, 3vw, 2rem);
@@ -94,8 +94,8 @@
   color: var(--text-secondary);
 
   opacity: 1;
-  animation: fadeIn 1s ease-out both;
-  animation-delay: 0.7s;
+  animation: fadeIn 1.5s ease-out both;
+  animation-delay: 1s;
   line-height: 1.5;
 
   @media (prefers-reduced-motion: reduce) {
@@ -150,8 +150,8 @@
   background: var(--accent);
   color: var(--text-on-accent);
   border: 2px solid var(--accent);
-  animation: buttonSlideIn 0.5s ease-out both;
-  animation-delay: 1.2s;
+  animation: buttonSlideIn 0.8s ease-out both;
+  animation-delay: 1.7s;
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;
@@ -162,8 +162,8 @@
   background-color: var(--bg-card);
   color: var(--text-primary);
   border: 2px solid var(--border-color);
-  animation: buttonSlideIn 0.5s ease-out both;
-  animation-delay: 1.5s;
+  animation: buttonSlideIn 0.8s ease-out both;
+  animation-delay: 2.1s;
 
   @media (prefers-reduced-motion: reduce) {
     animation: none;

--- a/src/app/(index)/portfolio.module.scss
+++ b/src/app/(index)/portfolio.module.scss
@@ -1,33 +1,15 @@
 @use "@/styles/reorder" as r;
 @use "@/styles/modal" as m;
 
-@keyframes fadeInUp {
-  from { opacity: 0; transform: translateY(20px); }
-  to { opacity: 1; transform: translateY(0); }
-}
-
-@keyframes scaleIn {
-  from { opacity: 0; transform: scale(0.9); }
-  to { opacity: 1; transform: scale(1); }
-}
-
 .sectionHeader {
   font-size: var(--fs-title);
   padding-block: 0.5em;
-
-  opacity: 0;
-  animation: fadeInUp 0.8s ease-out forwards;
-  animation-delay: 0.3s; /* Start slightly after the header animations begin */
 }
 
 .sectionDescription {
   font-size: 1.15rem;
   padding-block: 0.5em;
   color: var(--text-secondary);
-
-  opacity: 0;
-  animation: fadeInUp 0.8s ease-out forwards;
-  animation-delay: 0.6s;
 }
 
 .quickLinks {
@@ -57,7 +39,20 @@
   padding: 1.5rem;
   text-align: center;
   box-shadow: var(--shadow-sm);
-  transition: all 0.3s ease-in-out;
+  // Hover lift uses the `transform` longhand so it never collides with the
+  // scroll-reveal entrance, which animates the `translate` longhand. Both the
+  // entrance (opacity/translate, staggered) and the hover (transform/box-shadow,
+  // immediate) live in one declaration so neither `transition` shorthand clobbers
+  // the other. The delay list lines up with the property list.
+  transition:
+    opacity var(--dur-slow) var(--ease-out),
+    translate var(--dur-slow) var(--ease-out),
+    transform var(--dur-base) var(--ease-out),
+    box-shadow var(--dur-base) var(--ease-standard);
+  transition-delay:
+    calc(var(--reveal-index, 0) * var(--reveal-stagger)),
+    calc(var(--reveal-index, 0) * var(--reveal-stagger)),
+    0s, 0s;
   border: 1px solid var(--border-color);
 
   width: 300px;
@@ -68,9 +63,6 @@
   flex-direction: column;
 
   height: auto;
-
-  opacity: 0;
-  animation: scaleIn 0.6s ease-out forwards;
 
   .shortDescription {
     display: none;
@@ -113,31 +105,6 @@
     color: var(--text-primary);
   }
 
-  /* Apply different delays based on card index */
-  &:nth-child(1) {
-    animation-delay: 1s;
-
-    .quickLinkIcon {
-      animation-delay: 1s;
-    }
-  }
-
-  &:nth-child(2) {
-    animation-delay: 1.2s;
-
-    .quickLinkIcon {
-      animation-delay: 1.2s;
-    }
-  }
-
-  &:nth-child(3) {
-    animation-delay: 1.4s;
-
-    .quickLinkIcon {
-      animation-delay: 1.4s;
-    }
-  }
-
   @media (min-width: 800px) {
     padding: 1.75rem;
   }
@@ -150,7 +117,7 @@
 }
 
 .quickLinkCard:hover {
-  translate: 0 -5px;
+  transform: translateY(-5px);
   box-shadow: var(--shadow-md);
 
   & > h3 {
@@ -171,9 +138,6 @@
   margin: 0 auto 1.25rem;
   font-size: 1.5rem;
   color: var(--accent-text);
-
-  /* Subtle icon animation */
-  animation: fadeInUp 0.75s ease-out 0.2s backwards;
 
   @media (min-width: 800px) {
     width: 70px;
@@ -198,7 +162,7 @@
 
   font-size: 1.1rem;
   color: var(--text-primary);
-  transition: color 0.3s ease-in-out;
+  transition: color var(--dur-base) ease-in-out;
 
   @media (min-width: 800px) {
     font-size: 1.25rem;
@@ -223,7 +187,8 @@
   border-radius: var(--radius-sm);
   width: 85%;
   align-self: center;
-  transition: all 0.3s ease-in-out;
+  transition: transform var(--dur-base) var(--ease-out),
+              box-shadow var(--dur-base) var(--ease-standard);
 
   @media (min-width: 800px) {
     padding-block: 0.85rem;
@@ -245,12 +210,10 @@
 
 // The admin card is a faithful preview of the public card; it only needs to be a
 // positioning context for the overlay controls. Editing happens in the modal.
-// The entrance fade-in is disabled here: dragging swaps cards in and out of the
-// DOM, which would otherwise replay the (delayed) animation and make cards appear
-// to vanish mid-drag or on drop. Visitors still get the animated entrance.
+// Admin cards never carry the scroll-reveal class (so dragging can't re-hide
+// them); visitors still get the staggered entrance.
 .adminCard {
   position: relative;
-  animation: none;
   opacity: 1;
 }
 
@@ -293,7 +256,8 @@
   color: var(--text-secondary);
   cursor: pointer;
   font-size: 1rem;
-  transition: all 0.2s ease-in-out;
+  transition: border-color var(--dur-fast) var(--ease-standard),
+              color var(--dur-fast) var(--ease-standard);
 
   svg { font-size: 1.75rem; }
 
@@ -312,11 +276,10 @@
 }
 
 .floating {
-  // The float clone mounts fresh mid-drag; without this it would replay the
-  // card's entrance animation (which starts at opacity 0 and, for the first few
-  // cards, waits out a 1s+ delay) and appear to vanish while being dragged.
-  animation: none;
+  // Admin drag clone — kept fully opaque and untransformed by entrance state
+  // (it never carries the `.reveal` class) so it tracks the cursor cleanly.
   opacity: 1;
+  translate: none;
   @include r.floating-card;
 }
 

--- a/src/app/(index)/portfolio.module.scss
+++ b/src/app/(index)/portfolio.module.scss
@@ -162,7 +162,6 @@
 
   font-size: 1.1rem;
   color: var(--text-primary);
-  transition: color var(--dur-base) ease-in-out;
 
   @media (min-width: 800px) {
     font-size: 1.25rem;

--- a/src/app/admin/media/media.module.scss
+++ b/src/app/admin/media/media.module.scss
@@ -422,7 +422,7 @@
   display: flex;
   flex-direction: column;
   box-shadow: 0 1px 2px rgba(15, 23, 42, 0.05);
-  transition: box-shadow 0.15s ease, transform 0.15s ease;
+  transition: box-shadow var(--dur-fast) ease, transform var(--dur-fast) ease;
 
   &:hover {
     box-shadow: 0 6px 18px rgba(15, 23, 42, 0.12);
@@ -464,7 +464,7 @@
     background: var(--bg-card);
     box-shadow: 0 1px 3px rgba(15, 23, 42, 0.25);
     cursor: pointer;
-    transition: background 0.12s ease, border-color 0.12s ease;
+    transition: background var(--dur-fast) ease, border-color var(--dur-fast) ease;
 
     &::after {
       content: "";

--- a/src/app/contact/contact.module.scss
+++ b/src/app/contact/contact.module.scss
@@ -36,7 +36,7 @@
   padding: 3rem;
   position: relative;
   overflow: hidden;
-  animation: pageFadeIn 0.5s ease-out 0.1s both;
+  animation: pageFadeIn 0.8s ease-out 0.15s both;
 
   @media (max-width: 768px) {
     padding: 2rem;
@@ -94,7 +94,7 @@
     padding: 1rem;
     border-radius: var(--radius-sm);
     border: 1px solid;
-    animation: fade-in 0.5s ease-out;
+    animation: fade-in 0.8s ease-out;
   }
 
   .formSubmitSuccess {

--- a/src/app/projects/Projects.tsx
+++ b/src/app/projects/Projects.tsx
@@ -1,280 +1,59 @@
 "use client";
 import { camelCaseToSentence } from "@/utils/string";
 import styles from "./projects.module.scss";
-import Link from "next/link";
-import Image from "next/image";
-import { useEffect, useId, useLayoutEffect, useRef, useState } from "react";
+import { Suspense, useEffect, useLayoutEffect, useRef, useState } from "react";
 import { useRouter, useSearchParams } from "next/navigation";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import {
-  faTag,
-  faStar,
-  faEye,
-  faEyeSlash,
-  faGripVertical,
-  faBoxArchive,
-  faRotateLeft,
-  faImage,
-  faPlus,
-  faXmark
-} from "@fortawesome/free-solid-svg-icons";
-import EditableText from "@/components/EditableText";
-import Modal from "@/components/Modal";
-import AssetPicker from "@/components/RichTextEditor/AssetPicker";
-import { useDragReorder } from "@/components/useDragReorder";
-import { useTilt } from "@/components/useTilt";
-import { useSiteConfig } from "@/components/useSiteConfig";
-import {
-  updateContentField,
-  createProject,
-  setProjectImage
-} from "@/app/admin/contentActions";
-import { projectFlags } from "@/lib/siteConfig";
+import ProjectsBody from "./ProjectsBody";
 
 /**
- * Tag pills for a project. Visitors see the original read-only chip list; admins
- * get the same chips with a per-tag remove (×) plus an inline "add tag" input.
- * Tags stay a plain string array on the Project (no Tag entity) — `onChange`
- * persists the full next array.
+ * Skeleton card grid shown by the Suspense fallback while the streamed projects
+ * list resolves. Only the cards animate — the banner and filter above are
+ * already on screen. Reuses the real `.cards`/`.card` box metrics so the live
+ * cards swap in without shifting the layout.
  */
-function TagEditor({ project, isAdmin, onChange }: any) {
-  const [draft, setDraft] = useState("");
-
-  if (!isAdmin) {
-    return (
-      <ul>
-        {project.tags.map((tag: string) => (
-          <li key={tag}><FontAwesomeIcon icon={faTag} />{tag}</li>
-        ))}
-      </ul>
-    );
-  }
-
-  function addTag() {
-    const value = draft.trim();
-    setDraft("");
-    if (!value || project.tags.includes(value)) return;
-    onChange(project, [...project.tags, value]);
-  }
-
-  function removeTag(tag: string) {
-    onChange(project, project.tags.filter((t: string) => t !== tag));
-  }
-
+function CardsSkeleton() {
   return (
-    <ul className={styles.tagEditorList}>
-      {project.tags.map((tag: string) => (
-        <li key={tag}>
-          <FontAwesomeIcon icon={faTag} />{tag}
-          <button
-            type="button"
-            className={styles.tagRemove}
-            aria-label={`Remove tag ${tag}`}
-            onClick={() => removeTag(tag)}
-          >
-            <FontAwesomeIcon icon={faXmark} />
-          </button>
-        </li>
+    <div className={styles.cards} role="status" aria-label="Loading projects">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <div key={i} className={styles.skeletonCard} aria-hidden>
+          <div className={styles.skeletonThumb} />
+          <div className={styles.skeletonBody}>
+            <div className={`${styles.skeletonLine} ${styles.skeletonLineTitle}`} />
+            <div className={styles.skeletonLine} />
+            <div className={`${styles.skeletonLine} ${styles.skeletonLineShort}`} />
+            <div className={styles.skeletonButton} />
+          </div>
+        </div>
       ))}
-      <li className={styles.tagInputChip}>
-        <input
-          className={styles.tagInput}
-          value={draft}
-          onChange={(e) => setDraft(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === "Enter") {
-              e.preventDefault();
-              addTag();
-            } else if (e.key === "Backspace" && draft === "" && project.tags.length) {
-              removeTag(project.tags[project.tags.length - 1]);
-            }
-          }}
-          onBlur={addTag}
-          placeholder="Add tag…"
-          aria-label="Add tag"
-        />
-      </li>
-    </ul>
-  );
-}
-
-function ProjectCard({
-  project,
-  priority,
-  isAdmin,
-  flags,
-  enumValues,
-  onToggle,
-  onArchive,
-  onEditImage,
-  onToggleType,
-  onTagsChange,
-  onHandlePointerDown,
-  onHandleKeyDown,
-  innerRef,
-  floating
-}: any) {
-  const hidden = isAdmin && !flags.visible;
-  const archived = isAdmin && flags.archived;
-
-  // Pointer tilt for visitors only (admin cards are draggable/editable).
-  const tilt = useTilt();
-  const tiltProps = isAdmin ? {} : tilt;
-
-  return (
-    <div
-      ref={innerRef}
-      className={`${styles.card} ${hidden ? styles.hiddenCard : ""} ${
-        archived ? styles.archivedCard : ""
-      } ${floating ? styles.floating : ""}`}
-      {...tiltProps}
-    >
-      <div className={styles.thumbnail}>
-        {project.image && (
-          <Image
-            src={project.image.url}
-            // Decorative: the project title is announced by the adjacent <h3>, so
-            // an empty alt avoids a duplicate reading. WCAG 1.1.1.
-            alt=""
-            className={styles.thumbnailImage}
-            width={800}
-            height={400}
-            priority={priority}
-          />
-        )}
-        {/* Decorative title overlay on the thumbnail — the real heading is the
-            <h3> in the card body, so this is hidden from assistive tech to avoid
-            announcing the title twice. */}
-        <span className={styles.thumbTitle} aria-hidden="true">{project.title}</span>
-
-        {isAdmin && (
-          <div className={styles.adminOverlay}>
-            {onHandlePointerDown && (
-              <button
-                type="button"
-                className={styles.dragHandle}
-                aria-label="Reorder project. Press arrow keys to move, or drag."
-                onPointerDown={onHandlePointerDown}
-                onKeyDown={onHandleKeyDown}
-              >
-                <FontAwesomeIcon icon={faGripVertical} />
-              </button>
-            )}
-            <button
-              type="button"
-              aria-label="Change image"
-              title="Change image"
-              onClick={() => onEditImage(project)}
-            >
-              <FontAwesomeIcon icon={faImage} />
-            </button>
-            <button
-              type="button"
-              className={flags.featured ? styles.flagActive : ""}
-              aria-label="Toggle featured"
-              onClick={() => onToggle(project.slug, "featured")}
-            >
-              <FontAwesomeIcon icon={faStar} />
-            </button>
-            <button
-              type="button"
-              className={flags.visible ? styles.flagActive : ""}
-              aria-label="Toggle visibility"
-              onClick={() => onToggle(project.slug, "visible")}
-            >
-              <FontAwesomeIcon icon={flags.visible ? faEye : faEyeSlash} />
-            </button>
-            <button
-              type="button"
-              className={archived ? styles.flagActive : ""}
-              aria-label={archived ? "Restore project" : "Archive project"}
-              title={archived ? "Restore project" : "Archive project"}
-              onClick={() => onArchive(project.slug, !archived)}
-            >
-              <FontAwesomeIcon icon={archived ? faRotateLeft : faBoxArchive} />
-            </button>
-          </div>
-        )}
-      </div>
-
-      <div className={styles.cardContainer}>
-        <h2>
-          <EditableText model="Project" id={project.id} field="title" value={project.title} editable={isAdmin}>
-            {project.title}
-          </EditableText>
-        </h2>
-        <p>
-          <EditableText model="Project" id={project.id} field="description" value={project.description} editable={isAdmin} multiline>
-            {project.description}
-          </EditableText>
-        </p>
-
-        <TagEditor project={project} isAdmin={isAdmin} onChange={onTagsChange} />
-
-        {isAdmin && (
-          <div className={styles.typeChips}>
-            {enumValues.map((type: any) => {
-              const active = project.projectType.includes(type.name);
-              return (
-                <button
-                  key={type.name}
-                  type="button"
-                  className={`${styles.typeChip} ${active ? styles.typeChipActive : ""}`}
-                  onClick={() => onToggleType(project, type.name)}
-                >
-                  {camelCaseToSentence(type.name)}
-                </button>
-              );
-            })}
-          </div>
-        )}
-
-        <Link href={`/projects/${project.slug}`}>View Details</Link>
-      </div>
     </div>
   );
 }
 
-export default function Projects({ projects, config, isAdmin = false }: any) {
+/**
+ * Page shell for /projects. Renders the type filter immediately (it only needs
+ * the fast `enumValues` meta), then streams the heavier card grid in beneath it
+ * via a Suspense boundary around `ProjectsBody`.
+ */
+export default function Projects({
+  projectsPromise,
+  enumValues,
+  config,
+  isAdmin = false,
+  initialProjectType = "all"
+}: any) {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const enumValues = projects["__type"].enumValues;
 
-  const [projectType, setProjectType] = useState<string>("all");
-  const [items, setItems] = useState<any[]>(projects.projects);
-  const { cfg, cfgRef, persist } = useSiteConfig(config);
-
-  // Image picker (project being re-imaged) and the New Project modal.
-  const [imageFor, setImageFor] = useState<any | null>(null);
-  const [showCreate, setShowCreate] = useState(false);
-  const [newTitle, setNewTitle] = useState("");
-  const [newSlug, setNewSlug] = useState("");
-  const [newTypes, setNewTypes] = useState<string[]>([]);
-  const [newImage, setNewImage] = useState<{ id: string; url: string } | null>(null);
-  const [newImagePicker, setNewImagePicker] = useState(false);
-  const [creating, setCreating] = useState(false);
-  const [createError, setCreateError] = useState("");
-  const newProjectTitleId = useId();
-
-  // Reset and dismiss the New Project dialog (shared by Cancel, Escape, and
-  // scrim click so the form never retains stale input on the next open).
-  function closeCreate() {
-    setShowCreate(false);
-    setNewTitle("");
-    setNewSlug("");
-    setNewTypes([]);
-    setNewImage(null);
-    setCreateError("");
-  }
-
-  useEffect(() => setItems(projects.projects), [projects.projects]);
+  // Seeded from the server-resolved query param so the right tab is active on
+  // first paint; the effect below keeps it in sync with client-side navigation.
+  const [projectType, setProjectType] = useState<string>(initialProjectType);
 
   useEffect(() => {
     const queriedProjectType = searchParams.get("projectType");
 
     function isValidProjectType() {
       return queriedProjectType &&
-             enumValues.some((enumType: any) => enumType.name === queriedProjectType)
+             enumValues.some((enumType: any) => enumType.name === queriedProjectType);
     }
 
     setProjectType(isValidProjectType() ? queriedProjectType! : "all");
@@ -332,98 +111,6 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
       ?.focus();
   }
 
-  // Reordering is only meaningful (and unambiguous) when viewing all projects.
-  const canReorder = isAdmin && projectType === "all";
-
-  function toggleFlag(slug: string, key: "visible" | "featured") {
-    const current = projectFlags(cfgRef.current, slug);
-    persist({
-      ...cfgRef.current,
-      projects: { ...cfgRef.current.projects, [slug]: { ...current, [key]: !current[key] } }
-    });
-  }
-
-  function setArchived(slug: string, archived: boolean) {
-    const current = projectFlags(cfgRef.current, slug);
-    persist({
-      ...cfgRef.current,
-      projects: { ...cfgRef.current.projects, [slug]: { ...current, archived } }
-    });
-  }
-
-  async function toggleType(project: any, typeName: string) {
-    const has = project.projectType.includes(typeName);
-    const next = has
-      ? project.projectType.filter((t: string) => t !== typeName)
-      : [...project.projectType, typeName];
-
-    setItems((prev) => prev.map((p) => (p.slug === project.slug ? { ...p, projectType: next } : p)));
-    const result = await updateContentField("Project", project.id, "projectType", next);
-    if ("error" in result) {
-      alert(`Save failed: ${result.error}`);
-      router.refresh();
-    }
-  }
-
-  async function setTags(project: any, next: string[]) {
-    setItems((prev) => prev.map((p) => (p.slug === project.slug ? { ...p, tags: next } : p)));
-    const result = await updateContentField("Project", project.id, "tags", next);
-    if ("error" in result) {
-      alert(`Save failed: ${result.error}`);
-      router.refresh();
-    }
-  }
-
-  async function chooseImage(asset: any) {
-    const target = imageFor;
-    setImageFor(null);
-    if (!target) return;
-
-    setItems((prev) => prev.map((p) => (p.id === target.id ? { ...p, image: { url: asset.url } } : p)));
-    const result = await setProjectImage(target.id, asset.id);
-    if ("error" in result) {
-      alert(`Couldn't set image: ${result.error}`);
-      router.refresh();
-    }
-  }
-
-  async function submitCreate(e: React.FormEvent) {
-    e.preventDefault();
-    if (!newImage) {
-      setCreateError("Please choose an image.");
-      return;
-    }
-    setCreating(true);
-    setCreateError("");
-    const result = await createProject(newTitle, newSlug, newTypes, newImage.id);
-    if ("error" in result) {
-      setCreating(false);
-      setCreateError(result.error);
-    } else {
-      // Track it in the admin's order, then open it for inline fill-in.
-      await persist({ ...cfgRef.current, projectOrder: [...cfgRef.current.projectOrder, result.slug] });
-      router.push(`/projects/${result.slug}`);
-    }
-  }
-
-  const drag = useDragReorder({
-    items,
-    setItems,
-    getKey: (p) => p.slug,
-    onCommit: (slugs) => persist({ ...cfgRef.current, projectOrder: slugs })
-  });
-
-  // Archived projects (admin only) are pulled out into their own section.
-  const archivedItems = isAdmin
-    ? items.filter((p) => projectFlags(cfg, p.slug).archived)
-    : [];
-  const activeItems = items.filter((p) => !projectFlags(cfg, p.slug).archived);
-  const visible = activeItems.filter(
-    project => projectType === "all" || project.projectType.includes(projectType)
-  );
-
-  const draggingProject = drag.draggingKey ? items.find((p) => p.slug === drag.draggingKey) : null;
-
   return (
     <main className={styles.container} id="main-content" tabIndex={-1}>
       <div
@@ -467,192 +154,15 @@ export default function Projects({ projects, config, isAdmin = false }: any) {
           ))}
       </div>
 
-      {isAdmin && (
-        <div className={styles.adminToolbar}>
-          <button type="button" className={styles.newProjectButton} onClick={() => setShowCreate(true)}>
-            <FontAwesomeIcon icon={faPlus} /> New Project
-          </button>
-        </div>
-      )}
-
-      {isAdmin && (
-        <div className="srOnly" role="status" aria-live="polite">{drag.announcement}</div>
-      )}
-
-      <div
-        className={styles.cards}
-        role="tabpanel"
-        id="projects-panel"
-        aria-labelledby={`projects-tab-${projectType}`}
-      >
-        {visible.map((project) => (
-          project.slug === drag.draggingKey ? (
-            // The lifted card leaves a gap here; the real card floats by the cursor.
-            <div key={project.slug} className={styles.placeholder} style={{ height: drag.size.h }} />
-          ) : (
-            <ProjectCard
-              project={project}
-              key={project.slug}
-              innerRef={drag.registerCard(project.slug)}
-              priority={items.indexOf(project) < 3}
-              isAdmin={isAdmin}
-              flags={projectFlags(cfg, project.slug)}
-              enumValues={enumValues}
-              onToggle={toggleFlag}
-              onArchive={setArchived}
-              onEditImage={setImageFor}
-              onToggleType={toggleType}
-              onTagsChange={setTags}
-              onHandlePointerDown={
-                canReorder ? (e: React.PointerEvent) => drag.startDrag(items.indexOf(project), project.slug, e) : undefined
-              }
-              onHandleKeyDown={canReorder ? drag.keyboardReorder(project.slug) : undefined}
-            />
-          )
-        ))}
-      </div>
-
-      {isAdmin && archivedItems.length > 0 && (
-        <details className={styles.archivedSection}>
-          <summary>Archived projects ({archivedItems.length})</summary>
-          <div className={styles.cards}>
-            {archivedItems.map((project) => (
-              <ProjectCard
-                project={project}
-                key={project.slug}
-                isAdmin={isAdmin}
-                flags={projectFlags(cfg, project.slug)}
-                enumValues={enumValues}
-                onToggle={toggleFlag}
-                onArchive={setArchived}
-                onEditImage={setImageFor}
-                onToggleType={toggleType}
-                onTagsChange={setTags}
-              />
-            ))}
-          </div>
-        </details>
-      )}
-
-      {draggingProject && (
-        <div className={styles.floatingLayer} style={drag.floatingStyle}>
-          <ProjectCard
-            project={draggingProject}
-            isAdmin={isAdmin}
-            flags={projectFlags(cfg, draggingProject.slug)}
-            enumValues={enumValues}
-            onToggle={() => {}}
-            onArchive={() => {}}
-            onEditImage={() => {}}
-            onToggleType={() => {}}
-            onTagsChange={() => {}}
-            floating
-          />
-        </div>
-      )}
-
-      {imageFor && (
-        <AssetPicker
-          title="Set project image"
-          onSelect={chooseImage}
-          onClose={() => setImageFor(null)}
+      <Suspense fallback={<CardsSkeleton />}>
+        <ProjectsBody
+          projectsPromise={projectsPromise}
+          projectType={projectType}
+          enumValues={enumValues}
+          config={config}
+          isAdmin={isAdmin}
         />
-      )}
-
-      {newImagePicker && (
-        <AssetPicker
-          title="Choose project image"
-          onSelect={(asset) => {
-            setNewImage({ id: asset.id, url: asset.url });
-            setNewImagePicker(false);
-          }}
-          onClose={() => setNewImagePicker(false)}
-        />
-      )}
-
-      {showCreate && (
-        <Modal
-          onClose={() => { if (!creating) closeCreate(); }}
-          labelledBy={newProjectTitleId}
-          overlayClassName={styles.modalOverlay}
-          closeOnOverlayClick={!creating}
-        >
-          <form className={styles.modal} onSubmit={submitCreate}>
-            <h2 className={styles.modalTitle} id={newProjectTitleId}>New Project</h2>
-
-            <label className={styles.field}>
-              <span>Title</span>
-              <input value={newTitle} onChange={(e) => setNewTitle(e.target.value)} required autoFocus />
-            </label>
-
-            <label className={styles.field}>
-              <span>Slug</span>
-              <input
-                value={newSlug}
-                onChange={(e) => setNewSlug(e.target.value)}
-                placeholder="my-project"
-                required
-              />
-            </label>
-
-            <fieldset className={styles.field}>
-              <legend>Type</legend>
-              <div className={styles.typeChips}>
-                {enumValues.map((type: any) => {
-                  const active = newTypes.includes(type.name);
-                  return (
-                    <button
-                      key={type.name}
-                      type="button"
-                      className={`${styles.typeChip} ${active ? styles.typeChipActive : ""}`}
-                      onClick={() =>
-                        setNewTypes((prev) =>
-                          active ? prev.filter((t) => t !== type.name) : [...prev, type.name]
-                        )
-                      }
-                    >
-                      {camelCaseToSentence(type.name)}
-                    </button>
-                  );
-                })}
-              </div>
-            </fieldset>
-
-            <div className={styles.field}>
-              <span>Image</span>
-              <button
-                type="button"
-                className={styles.imageChoice}
-                onClick={() => setNewImagePicker(true)}
-              >
-                {newImage ? (
-                  <img src={newImage.url} alt="Selected project image" />
-                ) : (
-                  <span className={styles.imageChoicePlaceholder}>
-                    <FontAwesomeIcon icon={faImage} /> Choose image
-                  </span>
-                )}
-              </button>
-            </div>
-
-            {createError && <p className={styles.modalError} role="alert">{createError}</p>}
-
-            <div className={styles.modalActions}>
-              <button
-                type="button"
-                className={styles.modalCancel}
-                onClick={closeCreate}
-                disabled={creating}
-              >
-                Cancel
-              </button>
-              <button type="submit" className={styles.modalConfirm} disabled={creating}>
-                {creating ? "Creating…" : "Create & edit"}
-              </button>
-            </div>
-          </form>
-        </Modal>
-      )}
+      </Suspense>
     </main>
   );
 }

--- a/src/app/projects/ProjectsBody.tsx
+++ b/src/app/projects/ProjectsBody.tsx
@@ -1,0 +1,564 @@
+"use client";
+import { camelCaseToSentence } from "@/utils/string";
+import styles from "./projects.module.scss";
+import Link from "next/link";
+import Image from "next/image";
+import { use, useEffect, useId, useState } from "react";
+import { useRouter } from "next/navigation";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faTag,
+  faStar,
+  faEye,
+  faEyeSlash,
+  faGripVertical,
+  faBoxArchive,
+  faRotateLeft,
+  faImage,
+  faPlus,
+  faXmark
+} from "@fortawesome/free-solid-svg-icons";
+import EditableText from "@/components/EditableText";
+import Modal from "@/components/Modal";
+import AssetPicker from "@/components/RichTextEditor/AssetPicker";
+import { useDragReorder } from "@/components/useDragReorder";
+import { useTilt } from "@/components/useTilt";
+import { useSiteConfig } from "@/components/useSiteConfig";
+import {
+  updateContentField,
+  createProject,
+  setProjectImage
+} from "@/app/admin/contentActions";
+import { projectFlags } from "@/lib/siteConfig";
+
+/**
+ * Tag pills for a project. Visitors see the original read-only chip list; admins
+ * get the same chips with a per-tag remove (×) plus an inline "add tag" input.
+ * Tags stay a plain string array on the Project (no Tag entity) — `onChange`
+ * persists the full next array.
+ */
+function TagEditor({ project, isAdmin, onChange }: any) {
+  const [draft, setDraft] = useState("");
+
+  if (!isAdmin) {
+    return (
+      <ul>
+        {project.tags.map((tag: string) => (
+          <li key={tag}><FontAwesomeIcon icon={faTag} />{tag}</li>
+        ))}
+      </ul>
+    );
+  }
+
+  function addTag() {
+    const value = draft.trim();
+    setDraft("");
+    if (!value || project.tags.includes(value)) return;
+    onChange(project, [...project.tags, value]);
+  }
+
+  function removeTag(tag: string) {
+    onChange(project, project.tags.filter((t: string) => t !== tag));
+  }
+
+  return (
+    <ul className={styles.tagEditorList}>
+      {project.tags.map((tag: string) => (
+        <li key={tag}>
+          <FontAwesomeIcon icon={faTag} />{tag}
+          <button
+            type="button"
+            className={styles.tagRemove}
+            aria-label={`Remove tag ${tag}`}
+            onClick={() => removeTag(tag)}
+          >
+            <FontAwesomeIcon icon={faXmark} />
+          </button>
+        </li>
+      ))}
+      <li className={styles.tagInputChip}>
+        <input
+          className={styles.tagInput}
+          value={draft}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter") {
+              e.preventDefault();
+              addTag();
+            } else if (e.key === "Backspace" && draft === "" && project.tags.length) {
+              removeTag(project.tags[project.tags.length - 1]);
+            }
+          }}
+          onBlur={addTag}
+          placeholder="Add tag…"
+          aria-label="Add tag"
+        />
+      </li>
+    </ul>
+  );
+}
+
+function ProjectCard({
+  project,
+  priority,
+  isAdmin,
+  flags,
+  enumValues,
+  onToggle,
+  onArchive,
+  onEditImage,
+  onToggleType,
+  onTagsChange,
+  onHandlePointerDown,
+  onHandleKeyDown,
+  innerRef,
+  floating
+}: any) {
+  const hidden = isAdmin && !flags.visible;
+  const archived = isAdmin && flags.archived;
+
+  // Pointer tilt for visitors only (admin cards are draggable/editable).
+  const tilt = useTilt();
+  const tiltProps = isAdmin ? {} : tilt;
+
+  return (
+    <div
+      ref={innerRef}
+      className={`${styles.card} ${hidden ? styles.hiddenCard : ""} ${
+        archived ? styles.archivedCard : ""
+      } ${floating ? styles.floating : ""}`}
+      {...tiltProps}
+    >
+      <div className={styles.thumbnail}>
+        {project.image && (
+          <Image
+            src={project.image.url}
+            // Decorative: the project title is announced by the adjacent <h3>, so
+            // an empty alt avoids a duplicate reading. WCAG 1.1.1.
+            alt=""
+            className={styles.thumbnailImage}
+            width={800}
+            height={400}
+            priority={priority}
+          />
+        )}
+        {/* Decorative title overlay on the thumbnail — the real heading is the
+            <h3> in the card body, so this is hidden from assistive tech to avoid
+            announcing the title twice. */}
+        <span className={styles.thumbTitle} aria-hidden="true">{project.title}</span>
+
+        {isAdmin && (
+          <div className={styles.adminOverlay}>
+            {onHandlePointerDown && (
+              <button
+                type="button"
+                className={styles.dragHandle}
+                aria-label="Reorder project. Press arrow keys to move, or drag."
+                onPointerDown={onHandlePointerDown}
+                onKeyDown={onHandleKeyDown}
+              >
+                <FontAwesomeIcon icon={faGripVertical} />
+              </button>
+            )}
+            <button
+              type="button"
+              aria-label="Change image"
+              title="Change image"
+              onClick={() => onEditImage(project)}
+            >
+              <FontAwesomeIcon icon={faImage} />
+            </button>
+            <button
+              type="button"
+              className={flags.featured ? styles.flagActive : ""}
+              aria-label="Toggle featured"
+              onClick={() => onToggle(project.slug, "featured")}
+            >
+              <FontAwesomeIcon icon={faStar} />
+            </button>
+            <button
+              type="button"
+              className={flags.visible ? styles.flagActive : ""}
+              aria-label="Toggle visibility"
+              onClick={() => onToggle(project.slug, "visible")}
+            >
+              <FontAwesomeIcon icon={flags.visible ? faEye : faEyeSlash} />
+            </button>
+            <button
+              type="button"
+              className={archived ? styles.flagActive : ""}
+              aria-label={archived ? "Restore project" : "Archive project"}
+              title={archived ? "Restore project" : "Archive project"}
+              onClick={() => onArchive(project.slug, !archived)}
+            >
+              <FontAwesomeIcon icon={archived ? faRotateLeft : faBoxArchive} />
+            </button>
+          </div>
+        )}
+      </div>
+
+      <div className={styles.cardContainer}>
+        <h2>
+          <EditableText model="Project" id={project.id} field="title" value={project.title} editable={isAdmin}>
+            {project.title}
+          </EditableText>
+        </h2>
+        <p>
+          <EditableText model="Project" id={project.id} field="description" value={project.description} editable={isAdmin} multiline>
+            {project.description}
+          </EditableText>
+        </p>
+
+        <TagEditor project={project} isAdmin={isAdmin} onChange={onTagsChange} />
+
+        {isAdmin && (
+          <div className={styles.typeChips}>
+            {enumValues.map((type: any) => {
+              const active = project.projectType.includes(type.name);
+              return (
+                <button
+                  key={type.name}
+                  type="button"
+                  className={`${styles.typeChip} ${active ? styles.typeChipActive : ""}`}
+                  onClick={() => onToggleType(project, type.name)}
+                >
+                  {camelCaseToSentence(type.name)}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
+        <Link href={`/projects/${project.slug}`}>View Details</Link>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * The data-dependent half of the projects page: the card grid plus all admin
+ * affordances (reorder, flags, tags, image, create). It reads the streamed
+ * `projectsPromise` via `use()`, so only this subtree suspends while the list
+ * loads — the banner and type filter (rendered by the parent) stay put.
+ */
+export default function ProjectsBody({
+  projectsPromise,
+  projectType,
+  enumValues,
+  config,
+  isAdmin = false
+}: any) {
+  const router = useRouter();
+  const projects = use(projectsPromise) as any[];
+
+  const [items, setItems] = useState<any[]>(projects);
+  const { cfg, cfgRef, persist } = useSiteConfig(config);
+
+  // Image picker (project being re-imaged) and the New Project modal.
+  const [imageFor, setImageFor] = useState<any | null>(null);
+  const [showCreate, setShowCreate] = useState(false);
+  const [newTitle, setNewTitle] = useState("");
+  const [newSlug, setNewSlug] = useState("");
+  const [newTypes, setNewTypes] = useState<string[]>([]);
+  const [newImage, setNewImage] = useState<{ id: string; url: string } | null>(null);
+  const [newImagePicker, setNewImagePicker] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState("");
+  const newProjectTitleId = useId();
+
+  // Reset and dismiss the New Project dialog (shared by Cancel, Escape, and
+  // scrim click so the form never retains stale input on the next open).
+  function closeCreate() {
+    setShowCreate(false);
+    setNewTitle("");
+    setNewSlug("");
+    setNewTypes([]);
+    setNewImage(null);
+    setCreateError("");
+  }
+
+  useEffect(() => setItems(projects), [projects]);
+
+  // Reordering is only meaningful (and unambiguous) when viewing all projects.
+  const canReorder = isAdmin && projectType === "all";
+
+  function toggleFlag(slug: string, key: "visible" | "featured") {
+    const current = projectFlags(cfgRef.current, slug);
+    persist({
+      ...cfgRef.current,
+      projects: { ...cfgRef.current.projects, [slug]: { ...current, [key]: !current[key] } }
+    });
+  }
+
+  function setArchived(slug: string, archived: boolean) {
+    const current = projectFlags(cfgRef.current, slug);
+    persist({
+      ...cfgRef.current,
+      projects: { ...cfgRef.current.projects, [slug]: { ...current, archived } }
+    });
+  }
+
+  async function toggleType(project: any, typeName: string) {
+    const has = project.projectType.includes(typeName);
+    const next = has
+      ? project.projectType.filter((t: string) => t !== typeName)
+      : [...project.projectType, typeName];
+
+    setItems((prev) => prev.map((p) => (p.slug === project.slug ? { ...p, projectType: next } : p)));
+    const result = await updateContentField("Project", project.id, "projectType", next);
+    if ("error" in result) {
+      alert(`Save failed: ${result.error}`);
+      router.refresh();
+    }
+  }
+
+  async function setTags(project: any, next: string[]) {
+    setItems((prev) => prev.map((p) => (p.slug === project.slug ? { ...p, tags: next } : p)));
+    const result = await updateContentField("Project", project.id, "tags", next);
+    if ("error" in result) {
+      alert(`Save failed: ${result.error}`);
+      router.refresh();
+    }
+  }
+
+  async function chooseImage(asset: any) {
+    const target = imageFor;
+    setImageFor(null);
+    if (!target) return;
+
+    setItems((prev) => prev.map((p) => (p.id === target.id ? { ...p, image: { url: asset.url } } : p)));
+    const result = await setProjectImage(target.id, asset.id);
+    if ("error" in result) {
+      alert(`Couldn't set image: ${result.error}`);
+      router.refresh();
+    }
+  }
+
+  async function submitCreate(e: React.FormEvent) {
+    e.preventDefault();
+    if (!newImage) {
+      setCreateError("Please choose an image.");
+      return;
+    }
+    setCreating(true);
+    setCreateError("");
+    const result = await createProject(newTitle, newSlug, newTypes, newImage.id);
+    if ("error" in result) {
+      setCreating(false);
+      setCreateError(result.error);
+    } else {
+      // Track it in the admin's order, then open it for inline fill-in.
+      await persist({ ...cfgRef.current, projectOrder: [...cfgRef.current.projectOrder, result.slug] });
+      router.push(`/projects/${result.slug}`);
+    }
+  }
+
+  const drag = useDragReorder({
+    items,
+    setItems,
+    getKey: (p) => p.slug,
+    onCommit: (slugs) => persist({ ...cfgRef.current, projectOrder: slugs })
+  });
+
+  // Archived projects (admin only) are pulled out into their own section.
+  const archivedItems = isAdmin
+    ? items.filter((p) => projectFlags(cfg, p.slug).archived)
+    : [];
+  const activeItems = items.filter((p) => !projectFlags(cfg, p.slug).archived);
+  const visible = activeItems.filter(
+    project => projectType === "all" || project.projectType.includes(projectType)
+  );
+
+  const draggingProject = drag.draggingKey ? items.find((p) => p.slug === drag.draggingKey) : null;
+
+  return (
+    <>
+      {isAdmin && (
+        <div className={styles.adminToolbar}>
+          <button type="button" className={styles.newProjectButton} onClick={() => setShowCreate(true)}>
+            <FontAwesomeIcon icon={faPlus} /> New Project
+          </button>
+        </div>
+      )}
+
+      {isAdmin && (
+        <div className="srOnly" role="status" aria-live="polite">{drag.announcement}</div>
+      )}
+
+      <div
+        className={`${styles.cards} ${styles.cardsEnter}`}
+        role="tabpanel"
+        id="projects-panel"
+        aria-labelledby={`projects-tab-${projectType}`}
+      >
+        {visible.map((project) => (
+          project.slug === drag.draggingKey ? (
+            // The lifted card leaves a gap here; the real card floats by the cursor.
+            <div key={project.slug} className={styles.placeholder} style={{ height: drag.size.h }} />
+          ) : (
+            <ProjectCard
+              project={project}
+              key={project.slug}
+              innerRef={drag.registerCard(project.slug)}
+              priority={items.indexOf(project) < 3}
+              isAdmin={isAdmin}
+              flags={projectFlags(cfg, project.slug)}
+              enumValues={enumValues}
+              onToggle={toggleFlag}
+              onArchive={setArchived}
+              onEditImage={setImageFor}
+              onToggleType={toggleType}
+              onTagsChange={setTags}
+              onHandlePointerDown={
+                canReorder ? (e: React.PointerEvent) => drag.startDrag(items.indexOf(project), project.slug, e) : undefined
+              }
+              onHandleKeyDown={canReorder ? drag.keyboardReorder(project.slug) : undefined}
+            />
+          )
+        ))}
+      </div>
+
+      {isAdmin && archivedItems.length > 0 && (
+        <details className={styles.archivedSection}>
+          <summary>Archived projects ({archivedItems.length})</summary>
+          <div className={styles.cards}>
+            {archivedItems.map((project) => (
+              <ProjectCard
+                project={project}
+                key={project.slug}
+                isAdmin={isAdmin}
+                flags={projectFlags(cfg, project.slug)}
+                enumValues={enumValues}
+                onToggle={toggleFlag}
+                onArchive={setArchived}
+                onEditImage={setImageFor}
+                onToggleType={toggleType}
+                onTagsChange={setTags}
+              />
+            ))}
+          </div>
+        </details>
+      )}
+
+      {draggingProject && (
+        <div className={styles.floatingLayer} style={drag.floatingStyle}>
+          <ProjectCard
+            project={draggingProject}
+            isAdmin={isAdmin}
+            flags={projectFlags(cfg, draggingProject.slug)}
+            enumValues={enumValues}
+            onToggle={() => {}}
+            onArchive={() => {}}
+            onEditImage={() => {}}
+            onToggleType={() => {}}
+            onTagsChange={() => {}}
+            floating
+          />
+        </div>
+      )}
+
+      {imageFor && (
+        <AssetPicker
+          title="Set project image"
+          onSelect={chooseImage}
+          onClose={() => setImageFor(null)}
+        />
+      )}
+
+      {newImagePicker && (
+        <AssetPicker
+          title="Choose project image"
+          onSelect={(asset) => {
+            setNewImage({ id: asset.id, url: asset.url });
+            setNewImagePicker(false);
+          }}
+          onClose={() => setNewImagePicker(false)}
+        />
+      )}
+
+      {showCreate && (
+        <Modal
+          onClose={() => { if (!creating) closeCreate(); }}
+          labelledBy={newProjectTitleId}
+          overlayClassName={styles.modalOverlay}
+          closeOnOverlayClick={!creating}
+        >
+          <form className={styles.modal} onSubmit={submitCreate}>
+            <h2 className={styles.modalTitle} id={newProjectTitleId}>New Project</h2>
+
+            <label className={styles.field}>
+              <span>Title</span>
+              <input value={newTitle} onChange={(e) => setNewTitle(e.target.value)} required autoFocus />
+            </label>
+
+            <label className={styles.field}>
+              <span>Slug</span>
+              <input
+                value={newSlug}
+                onChange={(e) => setNewSlug(e.target.value)}
+                placeholder="my-project"
+                required
+              />
+            </label>
+
+            <fieldset className={styles.field}>
+              <legend>Type</legend>
+              <div className={styles.typeChips}>
+                {enumValues.map((type: any) => {
+                  const active = newTypes.includes(type.name);
+                  return (
+                    <button
+                      key={type.name}
+                      type="button"
+                      className={`${styles.typeChip} ${active ? styles.typeChipActive : ""}`}
+                      onClick={() =>
+                        setNewTypes((prev) =>
+                          active ? prev.filter((t) => t !== type.name) : [...prev, type.name]
+                        )
+                      }
+                    >
+                      {camelCaseToSentence(type.name)}
+                    </button>
+                  );
+                })}
+              </div>
+            </fieldset>
+
+            <div className={styles.field}>
+              <span>Image</span>
+              <button
+                type="button"
+                className={styles.imageChoice}
+                onClick={() => setNewImagePicker(true)}
+              >
+                {newImage ? (
+                  <img src={newImage.url} alt="Selected project image" />
+                ) : (
+                  <span className={styles.imageChoicePlaceholder}>
+                    <FontAwesomeIcon icon={faImage} /> Choose image
+                  </span>
+                )}
+              </button>
+            </div>
+
+            {createError && <p className={styles.modalError} role="alert">{createError}</p>}
+
+            <div className={styles.modalActions}>
+              <button
+                type="button"
+                className={styles.modalCancel}
+                onClick={closeCreate}
+                disabled={creating}
+              >
+                Cancel
+              </button>
+              <button type="submit" className={styles.modalConfirm} disabled={creating}>
+                {creating ? "Creating…" : "Create & edit"}
+              </button>
+            </div>
+          </form>
+        </Modal>
+      )}
+    </>
+  );
+}

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -1,6 +1,5 @@
 import Banner from "@/components/Banner";
 import Projects from "./Projects";
-import { Suspense } from "react";
 import type { Metadata } from "next";
 import { cmsQuery } from "@/lib/cms";
 import { isAuthed } from "@/lib/auth";
@@ -13,8 +12,10 @@ export const metadata : Metadata = {
 
 export const dynamic = "force-dynamic";
 
-const PROJECTS_QUERY = `
-  query Projects {
+// Banner copy + filter options. Small and fast, so the page shell (banner +
+// type filter) can render right away without waiting on the projects list.
+const META_QUERY = `
+  query ProjectsMeta {
     descriptions(where: { location: "Projects" }) {
       id
       header
@@ -25,6 +26,13 @@ const PROJECTS_QUERY = `
         name
       }
     }
+  }
+`;
+
+// The heavier list (with images). Fetched as a separate request and streamed
+// in via Suspense so it never blocks the banner or filter.
+const PROJECTS_QUERY = `
+  query Projects {
     projects {
       id
       title
@@ -39,17 +47,35 @@ const PROJECTS_QUERY = `
   }
 `;
 
-export default async function Page() {
-  const [projects, { data: config }, isAdmin] = await Promise.all([
-    cmsQuery(PROJECTS_QUERY),
+export default async function Page({
+  searchParams
+}: {
+  searchParams: Promise<{ projectType?: string | string[] }>;
+}) {
+  // Banner + filter only need the fast meta query; await it (and config/auth)
+  // so the shell renders immediately. The projects list is kicked off here but
+  // intentionally NOT awaited — it's passed down as a promise and streamed in.
+  const [meta, { data: config }, isAdmin, params] = await Promise.all([
+    cmsQuery(META_QUERY),
     getSiteConfig(),
-    isAuthed()
+    isAuthed(),
+    searchParams
   ]);
 
-  const description = projects.descriptions[0];
+  const description = meta.descriptions[0];
+  const enumValues = meta["__type"].enumValues;
 
-  // Order by config; admins also see hidden projects (dimmed in the UI).
-  const orderedProjects = applyConfigToProjects(projects.projects, config, isAdmin);
+  // Resolve the active filter on the server so the correct tab is selected on
+  // first paint rather than flashing "All" then correcting after hydration.
+  const queried = Array.isArray(params.projectType) ? params.projectType[0] : params.projectType;
+  const initialProjectType =
+    queried && enumValues.some((t: any) => t.name === queried) ? queried : "all";
+
+  // Order by config; admins also see hidden projects (dimmed in the UI). Kept
+  // as a promise so the client component can suspend just the card grid on it.
+  const projectsPromise = cmsQuery(PROJECTS_QUERY).then((data) =>
+    applyConfigToProjects(data.projects, config, isAdmin)
+  );
 
   return (
     <>
@@ -59,13 +85,13 @@ export default async function Page() {
         edit={{ isAdmin, model: "Description", id: description.id, titleField: "header", descriptionField: "description" }}
       />
 
-      <Suspense>
-        <Projects
-          projects={{ ...projects, projects: orderedProjects }}
-          config={config}
-          isAdmin={isAdmin}
-        />
-      </Suspense>
+      <Projects
+        projectsPromise={projectsPromise}
+        enumValues={enumValues}
+        config={config}
+        isAdmin={isAdmin}
+        initialProjectType={initialProjectType}
+      />
     </>
   );
 }

--- a/src/app/projects/projects.module.scss
+++ b/src/app/projects/projects.module.scss
@@ -6,7 +6,7 @@
   background-color: var(--bg-primary);
   // Match the body's theme transition so this strip eases in sync with the rest
   // of the page rather than snapping instantly.
-  transition: background-color 0.3s ease, color 0.3s ease;
+  transition: background-color var(--dur-base) ease, color var(--dur-base) ease;
   min-width: 100%;
   color: var(--text-primary);
   max-width: 600px;
@@ -108,8 +108,8 @@
   background: var(--accent-secondary);
   border-radius: var(--radius-sm);
   box-shadow: var(--shadow-sm);
-  transition: transform 0.32s cubic-bezier(0.22, 1, 0.36, 1),
-              width 0.32s cubic-bezier(0.22, 1, 0.36, 1);
+  transition: transform var(--dur-base) cubic-bezier(0.22, 1, 0.36, 1),
+              width var(--dur-base) cubic-bezier(0.22, 1, 0.36, 1);
   z-index: 0;
   pointer-events: none;
 
@@ -154,7 +154,7 @@
   // pointer tilt (--rx/--ry) rather than overwriting it.
   --ty: 0px;
   transform: perspective(900px) rotateX(var(--rx, 0deg)) rotateY(var(--ry, 0deg)) translateY(var(--ty));
-  transition: transform 0.25s ease-out, box-shadow 0.3s ease-in-out;
+  transition: transform var(--dur-base) ease-out, box-shadow var(--dur-base) ease-in-out;
 
   .thumbnail {
     aspect-ratio: 2/1;
@@ -173,7 +173,7 @@
       // a source ever deviates) rather than letterboxing it in a dark box.
       aspect-ratio: 2 / 1;
       object-fit: cover;
-      transition: transform 0.4s ease-in-out;
+      transition: transform var(--dur-slow) ease-in-out;
     }
 
     // Light, even scrim that holds the centered title; mostly lifts on hover to
@@ -183,7 +183,7 @@
       position: absolute;
       inset: 0;
       background-color: rgba($dark, 0.64);
-      transition: background-color 0.4s ease-in-out;
+      transition: background-color var(--dur-slow) ease-in-out;
       z-index: 1;
     }
 
@@ -205,7 +205,7 @@
       letter-spacing: -0.015em;
       font-size: 1.4rem;
       opacity: 1;
-      transition: opacity 0.3s ease-in-out;
+      transition: opacity var(--dur-base) ease-in-out;
     }
   }
 
@@ -221,7 +221,7 @@
       font-size: 1.2em;
       padding-block: 0.5em;
       color: var(--text-primary);
-      transition: color 0.3s ease-in-out;
+      transition: color var(--dur-base) ease-in-out;
     }
 
     & > p {
@@ -260,7 +260,7 @@
       padding-block: 1em;
       font-weight: bold;
       text-align: center;
-      transition: all 0.3s ease-in-out;
+      transition: all var(--dur-base) ease-in-out;
 
       &:hover {
         transform: translateY(-2px);
@@ -354,7 +354,7 @@
   color: var(--text-muted);
   cursor: pointer;
   font-size: 0.85em;
-  transition: all 0.15s ease-in-out;
+  transition: all var(--dur-fast) ease-in-out;
 
   &:hover {
     background: rgba(0, 0, 0, 0.18);
@@ -402,7 +402,7 @@
   color: $light;
   font-weight: bold;
   cursor: pointer;
-  transition: background 0.2s ease-in-out;
+  transition: background var(--dur-fast) ease-in-out;
 
   &:hover {
     background: color-mix(in srgb, var(--accent-secondary) 90%, #000);
@@ -426,7 +426,7 @@
   padding: 0.3em 0.75em;
   font-size: 0.8rem;
   cursor: pointer;
-  transition: all 0.2s ease-in-out;
+  transition: all var(--dur-fast) ease-in-out;
 
   &:hover {
     border-color: var(--accent);
@@ -530,4 +530,92 @@
 .modalConfirm {
   background: var(--accent-secondary);
   color: $light;
+}
+
+/* --- Loading skeletons ----------------------------------------------------- *
+ * Shown by loading.tsx while the force-dynamic page awaits the CMS query. The
+ * skeleton reuses the real `.cards`/`.card` box metrics so swapping in the live
+ * content produces no layout shift. */
+
+@keyframes shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}
+
+%shimmer {
+  background: linear-gradient(
+    90deg,
+    var(--bg-secondary) 25%,
+    var(--border-color) 50%,
+    var(--bg-secondary) 75%
+  );
+  background-size: 200% 100%;
+  animation: shimmer 1.4s ease-in-out infinite;
+}
+
+// Soft entrance for the real cards once the streamed list resolves, so the
+// swap from skeletons isn't abrupt.
+@keyframes projectsFadeIn {
+  from { opacity: 0; transform: translateY(8px); }
+  to { opacity: 1; transform: none; }
+}
+
+.cardsEnter {
+  animation: projectsFadeIn var(--dur-base) ease-out both;
+
+  @media (prefers-reduced-motion: reduce) {
+    animation: none;
+  }
+}
+
+.skeletonCard {
+  display: grid;
+  grid-template-rows: auto 1fr;
+  border-radius: var(--radius-md);
+  box-shadow: var(--shadow-sm);
+}
+
+.skeletonThumb {
+  @extend %shimmer;
+  aspect-ratio: 2 / 1;
+  border-radius: var(--radius-md) var(--radius-md) 0 0;
+}
+
+.skeletonBody {
+  background-color: var(--bg-card);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1em;
+  border-radius: 0 0 var(--radius-md) var(--radius-md);
+  border: 1px solid var(--border-color);
+  border-top: none;
+}
+
+.skeletonLine {
+  @extend %shimmer;
+  height: 0.85rem;
+  border-radius: var(--radius-sm);
+}
+
+.skeletonLineTitle {
+  height: 1.3rem;
+  width: 65%;
+}
+
+.skeletonLineShort {
+  width: 40%;
+}
+
+.skeletonButton {
+  @extend %shimmer;
+  height: 3rem;
+  margin-top: 1rem;
+  border-radius: var(--radius-sm);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  %shimmer {
+    animation: none;
+  }
 }

--- a/src/app/projects/projects.module.scss
+++ b/src/app/projects/projects.module.scss
@@ -6,7 +6,7 @@
   background-color: var(--bg-primary);
   // Match the body's theme transition so this strip eases in sync with the rest
   // of the page rather than snapping instantly.
-  transition: background-color var(--dur-base) ease, color var(--dur-base) ease;
+  transition: background-color var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard);
   min-width: 100%;
   color: var(--text-primary);
   max-width: 600px;
@@ -221,7 +221,7 @@
       font-size: 1.2em;
       padding-block: 0.5em;
       color: var(--text-primary);
-      transition: color var(--dur-base) ease-in-out;
+      transition: color var(--dur-base) var(--ease-standard);
     }
 
     & > p {

--- a/src/app/projects/projects.module.scss
+++ b/src/app/projects/projects.module.scss
@@ -51,7 +51,7 @@
     font-size: 0.9rem;
     white-space: nowrap;
     cursor: pointer;
-    transition: background var(--transition-fast), color var(--transition-fast), transform var(--transition-fast);
+    transition: background var(--transition-fast), transform var(--transition-fast);
 
     &:hover {
       background: var(--bg-primary);
@@ -221,7 +221,6 @@
       font-size: 1.2em;
       padding-block: 0.5em;
       color: var(--text-primary);
-      transition: color var(--dur-base) var(--ease-standard);
     }
 
     & > p {

--- a/src/components/Banner/banner.module.scss
+++ b/src/components/Banner/banner.module.scss
@@ -9,7 +9,7 @@
   );
   display: grid;
   place-items: center;
-  animation: pageFadeIn 0.5s ease-out both;
+  animation: pageFadeIn 0.8s ease-out both;
 }
 
 .container {

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -54,7 +54,7 @@
         background var(--transition),
         border-color var(--transition),
         box-shadow var(--transition),
-        transform 0.35s cubic-bezier(0.34, 1.56, 0.64, 1);
+        transform var(--dur-slow) cubic-bezier(0.34, 1.56, 0.64, 1);
 
       &:hover {
         background: var(--accent);
@@ -106,14 +106,14 @@
     gap: 0.5rem;
 
     li {
-      transition: 0.3s all ease-in-out;
+      transition: var(--dur-base) all ease-in-out;
     }
 
     a {
       color: var(--text-secondary);
       text-decoration: none;
       opacity: 0.8;
-      transition: 0.3s all ease-in-out;
+      transition: var(--dur-base) all ease-in-out;
 
       &:hover {
         color: var(--accent-text);

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -98,7 +98,9 @@ export default function Modal({
   return (
     <div
       ref={overlayRef}
-      className={overlayClassName}
+      // `modalAnimated` (global.scss) fades the scrim and settles the panel; it's
+      // appended here so every dialog gets the entrance with no per-caller CSS.
+      className={`${overlayClassName} modalAnimated`}
       role="dialog"
       aria-modal="true"
       aria-labelledby={labelledBy}

--- a/src/components/NavBar/NavBar.module.scss
+++ b/src/components/NavBar/NavBar.module.scss
@@ -135,7 +135,7 @@
   box-shadow: var(--shadow-md);
   display: flex;
   flex-direction: column;
-  animation: dropdownAppear 0.2s ease-in;
+  animation: dropdownAppear var(--dur-fast) ease-in;
 }
 
 .dropdownItem {
@@ -144,7 +144,7 @@
   color: var(--text-secondary);
   font-size: 1rem;
   font-weight: 500;
-  transition: all 0.2s ease;
+  transition: all var(--dur-fast) ease;
   position: relative;
 
   &:hover {

--- a/src/components/ProjectBlocks/ProjectBlocks.tsx
+++ b/src/components/ProjectBlocks/ProjectBlocks.tsx
@@ -1,4 +1,5 @@
 import RichTextWidget from "@/components/RichTextWidget";
+import Reveal from "@/components/Reveal";
 import type { Block } from "./blocks";
 import Hero from "./Hero";
 import FeatureGrid from "./FeatureGrid";
@@ -30,34 +31,46 @@ export default function ProjectBlocks({
 }) {
   return (
     <div className={`${styles.blocks} ${naturalHeroImage ? styles.naturalHeroImage : ""}`}>
-      {blocks.map((block) => {
-        switch (block.type) {
-          case "hero":
-            return <Hero key={block.id} block={block} />;
-          case "richText":
-            return (
-              <section key={block.id} className={`${styles.block} ${styles.measure}`}>
-                <RichTextWidget content={block.content} variant="bare" />
-              </section>
-            );
-          case "featureGrid":
-            return <FeatureGrid key={block.id} block={block} />;
-          case "stats":
-            return <Stats key={block.id} block={block} />;
-          case "techStack":
-            return <TechStack key={block.id} block={block} />;
-          case "gallery":
-            return <Gallery key={block.id} block={block} />;
-          case "video":
-            return <Video key={block.id} block={block} />;
-          case "callout":
-            return <Callout key={block.id} block={block} />;
-          case "cta":
-            return <Cta key={block.id} block={block} />;
-          default:
-            return null;
-        }
+      {blocks.map((block, index) => {
+        const content = renderBlock(block);
+        if (!content) return null;
+        // Each block reveals as it scrolls into view. Stagger is capped so blocks
+        // that share the first screen cascade subtly without long waits.
+        return (
+          <Reveal key={block.id} index={index % 3}>
+            {content}
+          </Reveal>
+        );
       })}
     </div>
   );
+}
+
+function renderBlock(block: Block) {
+  switch (block.type) {
+    case "hero":
+      return <Hero block={block} />;
+    case "richText":
+      return (
+        <section className={`${styles.block} ${styles.measure}`}>
+          <RichTextWidget content={block.content} variant="bare" />
+        </section>
+      );
+    case "featureGrid":
+      return <FeatureGrid block={block} />;
+    case "stats":
+      return <Stats block={block} />;
+    case "techStack":
+      return <TechStack block={block} />;
+    case "gallery":
+      return <Gallery block={block} />;
+    case "video":
+      return <Video block={block} />;
+    case "callout":
+      return <Callout block={block} />;
+    case "cta":
+      return <Cta block={block} />;
+    default:
+      return null;
+  }
 }

--- a/src/components/Reveal.tsx
+++ b/src/components/Reveal.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { type ReactNode } from "react";
+import { useReveal } from "./useReveal";
+
+/**
+ * Wraps server-rendered content in a self-observing scroll-reveal container, so
+ * sections settle in as they enter the viewport. Accepts Server Components as
+ * `children` (rendered on the server, passed through untouched). Pairs with the
+ * global `.reveal` / `.is-visible` classes; `index` drives the stagger delay.
+ */
+export default function Reveal({
+  children,
+  index = 0,
+  className = ""
+}: {
+  children: ReactNode;
+  index?: number;
+  className?: string;
+}) {
+  const { ref, isVisible } = useReveal<HTMLDivElement>();
+  return (
+    <div
+      ref={ref}
+      className={`reveal ${isVisible ? "is-visible" : ""} ${className}`}
+      style={{ ["--reveal-index" as any]: index }}
+    >
+      {children}
+    </div>
+  );
+}

--- a/src/components/RichTextWidget/RichText.module.scss
+++ b/src/components/RichTextWidget/RichText.module.scss
@@ -187,7 +187,7 @@ $mono: ui-monospace, "Cascadia Code", "JetBrains Mono", "Source Code Pro", Menlo
     text-decoration: none;
     position: relative;
     font-weight: 500;
-    transition: color 0.3s ease-in-out;
+    transition: color var(--dur-base) ease-in-out;
 
     &::after {
       content: '';
@@ -197,7 +197,7 @@ $mono: ui-monospace, "Cascadia Code", "JetBrains Mono", "Source Code Pro", Menlo
       width: 0;
       height: 2px;
       background: linear-gradient(90deg, var(--accent-secondary), color-mix(in srgb, var(--accent-secondary) 70%, #1e293b));
-      transition: width 0.3s ease;
+      transition: width var(--dur-base) ease;
     }
 
     &:hover {

--- a/src/components/useReveal.ts
+++ b/src/components/useReveal.ts
@@ -1,0 +1,62 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+/**
+ * Viewport-triggered reveal. Returns a `ref` to attach to the element to watch
+ * and an `isVisible` flag that flips to `true` the first time the element enters
+ * the viewport — then stays true (the observer disconnects, so the reveal never
+ * replays while scrolling).
+ *
+ * Pair with the global `.reveal` / `.is-visible` classes (see global.scss):
+ * apply `.reveal` always and add `.is-visible` when `isVisible` is true. For a
+ * staggered group, attach the ref to the container and set `--reveal-index` per
+ * child so they cascade in once the group scrolls into view.
+ *
+ * Reduced-motion or environments without IntersectionObserver start visible
+ * immediately, so the content is never gated behind motion.
+ */
+export function useReveal<T extends HTMLElement = HTMLElement>(options?: {
+  threshold?: number;
+  rootMargin?: string;
+}) {
+  const ref = useRef<T>(null);
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+
+    const prefersReduced =
+      typeof window !== "undefined" &&
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+
+    // No motion wanted, or no observer support: show the final state at once.
+    if (prefersReduced || typeof IntersectionObserver === "undefined") {
+      setIsVisible(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        for (const entry of entries) {
+          if (entry.isIntersecting) {
+            setIsVisible(true);
+            observer.unobserve(entry.target); // one-time: never replay
+          }
+        }
+      },
+      {
+        threshold: options?.threshold ?? 0.15,
+        // Fire slightly before the element is fully in view.
+        rootMargin: options?.rootMargin ?? "0px 0px -10% 0px"
+      }
+    );
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [options?.threshold, options?.rootMargin]);
+
+  return { ref, isVisible };
+}

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -84,7 +84,7 @@ body {
   background-color: var(--bg-primary);
   color: var(--text-primary);
   font-family: var(--font-body), system-ui, -apple-system, sans-serif;
-  transition: background-color var(--dur-base) ease, color var(--dur-base) ease;
+  transition: background-color var(--dur-base) var(--ease-standard), color var(--dur-base) var(--ease-standard);
 }
 
 // Site-wide text selection in the brand accent (theme-forked).

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -19,8 +19,25 @@
   // Height of the sticky NavBar (see NavBar.module.scss). Used so in-page scroll
   // targets (e.g. the skip-link's #main-content) clear the bar.
   --navbar-height: 70px;
-  --transition-fast: 0.2s ease;
-  --transition: 0.3s ease;
+
+  // --- Motion system -------------------------------------------------------
+  // One shared vocabulary for duration, easing, and reveal distance so motion
+  // stays consistent across the site (see .reveal below and useReveal.ts).
+  --dur-fast: 300ms;    // hovers, taps, small state changes
+  --dur-base: 500ms;    // default transitions, card hover lift
+  --dur-slow: 700ms;    // entrances, modal in
+  --dur-slower: 900ms;  // large/hero reveals
+
+  --ease-standard: cubic-bezier(0.4, 0, 0.2, 1);  // general UI state changes
+  --ease-out: cubic-bezier(0.22, 1, 0.36, 1);     // entrances / decelerate
+  --ease-in: cubic-bezier(0.4, 0, 1, 1);          // exits
+
+  --reveal-distance: 16px;  // travel for scroll-reveal entrances (kept subtle)
+  --reveal-stagger: 130ms;  // per-index delay for staggered groups
+
+  // Existing aliases, now expressed on the scale above (back-compat).
+  --transition-fast: var(--dur-fast) var(--ease-standard);
+  --transition: var(--dur-base) var(--ease-standard);
 
   // Shared vertical rhythm — one responsive scale for page/section padding.
   --section-padding: clamp(2.5rem, 5vw, 4rem);
@@ -67,7 +84,7 @@ body {
   background-color: var(--bg-primary);
   color: var(--text-primary);
   font-family: var(--font-body), system-ui, -apple-system, sans-serif;
-  transition: background-color 0.3s ease, color 0.3s ease;
+  transition: background-color var(--dur-base) ease, color var(--dur-base) ease;
 }
 
 // Site-wide text selection in the brand accent (theme-forked).
@@ -92,6 +109,57 @@ h1, h2, h3, h4, h5, h6 {
 @keyframes pageFadeIn {
   from { opacity: 0; transform: translateY(12px); }
   to   { opacity: 1; transform: translateY(0); }
+}
+
+// Shared modal entrance. Applied by the Modal shell (Modal.tsx) to the scrim it
+// controls, so every dialog — admin editors, the asset picker, the gallery
+// lightbox — fades its backdrop and settles its panel without per-module CSS.
+// The reduced-motion block below neutralizes both animations.
+@keyframes modalScrimIn {
+  from { opacity: 0; }
+  to   { opacity: 1; }
+}
+@keyframes modalSurfaceIn {
+  from { opacity: 0; transform: translateY(8px) scale(0.97); }
+  to   { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.modalAnimated {
+  animation: modalScrimIn var(--dur-fast) var(--ease-standard) both;
+}
+// The scrim's single styled panel (form/box) is its direct child.
+.modalAnimated > * {
+  animation: modalSurfaceIn var(--dur-slow) var(--ease-out) both;
+}
+
+// Shared scroll-reveal utility. Elements start shifted + transparent and settle
+// when JS adds `.is-visible` (driven by useReveal.ts on viewport entry). Kept in
+// this global file so the class names stay unhashed and any CSS module can apply
+// them. Group stagger comes from `--reveal-index` set inline per item.
+// Animates the `translate` longhand (not `transform`) so it composes with
+// cards that already use `transform` for pointer-tilt (.featured .card) without
+// clobbering it — mirroring the deliberate translate-not-transform choice the
+// featured entrance used before.
+.reveal {
+  opacity: 0;
+  translate: 0 var(--reveal-distance);
+  transition: opacity var(--dur-slow) var(--ease-out),
+              translate var(--dur-slow) var(--ease-out);
+  transition-delay: calc(var(--reveal-index, 0) * var(--reveal-stagger));
+  will-change: opacity, translate;
+}
+
+.reveal.is-visible {
+  opacity: 1;
+  translate: none;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .reveal {
+    opacity: 1;
+    translate: none;
+    transition: none;
+  }
 }
 
 // Honor reduced-motion globally: neutralizes the homepage entrance animations


### PR DESCRIPTION
This pull request refactors the entrance animations for the Featured Projects and Portfolio sections, replacing legacy keyframe-based fade/scale-in effects with a modern, scroll-triggered reveal system. The new approach uses a reusable `useReveal` hook and CSS transitions, enabling each card and header to animate into view with a smooth, staggered effect as the user scrolls. Admin views remain static for usability. The CSS is cleaned up to remove old animation code and unify transition logic, ensuring hover and entrance effects coexist seamlessly.

**Scroll-triggered reveal system:**

- Introduced the `useReveal` hook in both `FeaturedProjects.tsx` and `Portfolio.tsx`, allowing section headers and individual cards to animate their entrance based on scroll position, with support for staggered delays via the `--reveal-index` CSS variable. Admin views bypass the reveal for editing stability. [[1]](diffhunk://#diff-e8a1e797e046332dc9169ca76cb942ed1e926d819edb77a61f12f7a23e4530cfR11-R22) [[2]](diffhunk://#diff-e8a1e797e046332dc9169ca76cb942ed1e926d819edb77a61f12f7a23e4530cfL75-R86) [[3]](diffhunk://#diff-e8a1e797e046332dc9169ca76cb942ed1e926d819edb77a61f12f7a23e4530cfR101-R105) [[4]](diffhunk://#diff-e8a1e797e046332dc9169ca76cb942ed1e926d819edb77a61f12f7a23e4530cfL112-R139) [[5]](diffhunk://#diff-e8a1e797e046332dc9169ca76cb942ed1e926d819edb77a61f12f7a23e4530cfR162) [[6]](diffhunk://#diff-fbc607d1f65e9a56368840eaa873151c151a92c20295ce769f3a68cbaf3ba61fR9) [[7]](diffhunk://#diff-fbc607d1f65e9a56368840eaa873151c151a92c20295ce769f3a68cbaf3ba61fL69-R91) [[8]](diffhunk://#diff-fbc607d1f65e9a56368840eaa873151c151a92c20295ce769f3a68cbaf3ba61fR251-R255) [[9]](diffhunk://#diff-fbc607d1f65e9a56368840eaa873151c151a92c20295ce769f3a68cbaf3ba61fL322-R349) [[10]](diffhunk://#diff-fbc607d1f65e9a56368840eaa873151c151a92c20295ce769f3a68cbaf3ba61fR372)

**CSS animation and transition improvements:**

- Removed legacy keyframe entrance animations (such as `fadeInUp` and `scaleIn`) from `featured.module.scss` and `portfolio.module.scss`, and replaced them with a unified, property-specific transition system for opacity and translate, supporting staggered entrance via `--reveal-index`. [[1]](diffhunk://#diff-3806f8d6cb0a6cc7aea8f101404faf90e6c678036eb1f9d796703ce8877eab82L4-L10) [[2]](diffhunk://#diff-3806f8d6cb0a6cc7aea8f101404faf90e6c678036eb1f9d796703ce8877eab82L53-R63) [[3]](diffhunk://#diff-3806f8d6cb0a6cc7aea8f101404faf90e6c678036eb1f9d796703ce8877eab82L122-R129) [[4]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L4-L30) [[5]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L60-R55) [[6]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L72-L74) [[7]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L116-L140) [[8]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L226-R190) [[9]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L248-L253)

- Ensured hover and entrance transitions coexist without conflict by consolidating transition properties and delays, so that scroll-reveal and pointer interactions are smooth and independent. [[1]](diffhunk://#diff-3806f8d6cb0a6cc7aea8f101404faf90e6c678036eb1f9d796703ce8877eab82L53-R63) [[2]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L60-R55) [[3]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L226-R190)

**Minor animation timing adjustments:**

- Adjusted landing page animation durations and delays for a smoother, more cohesive entrance sequence. [[1]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL75-R75) [[2]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL97-R98) [[3]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL153-R154) [[4]](diffhunk://#diff-c1178824698c5cbddcc79e5a06dd7beb238be37817f1e4551fbfcc5bb21662ebL165-R166)

**Other style and transition refinements:**

- Updated transitions for button, card, and icon elements to use CSS variables for timing and easing, and removed unnecessary transitions or animation delays. [[1]](diffhunk://#diff-3806f8d6cb0a6cc7aea8f101404faf90e6c678036eb1f9d796703ce8877eab82L105-R109) [[2]](diffhunk://#diff-3806f8d6cb0a6cc7aea8f101404faf90e6c678036eb1f9d796703ce8877eab82L141-R145) [[3]](diffhunk://#diff-3806f8d6cb0a6cc7aea8f101404faf90e6c678036eb1f9d796703ce8877eab82L155) Fe976810L117R150, [[4]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L153-R120) [[5]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L175-L177) [[6]](diffhunk://#diff-91a491b19cc8d44bf523bcd2c4a06e030936f8d5873e21d24f92b381fcdc4a51L201)

This refactor modernizes the entrance animation system, improves user experience with scroll-based reveals, and simplifies the underlying code for easier maintenance.