### PR TITLE
Implement floating layer for dragged blocks with placeholder

### DIFF
--- a/src/components/ProjectBlocks/editor/ProjectPageEditor.module.scss
+++ b/src/components/ProjectBlocks/editor/ProjectPageEditor.module.scss
@@ -51,9 +51,21 @@
   overflow: hidden;
 }
 
-.floating {
+// Fixed layer that hosts the lifted block clone following the cursor.
+.floatingLayer {
   @include r.floating-layer;
+}
+
+.floating {
   @include r.floating-card;
+}
+
+// Dashed gap left in the list at the dragged block's live position, marking the
+// drop target as the order reflows.
+.placeholder {
+  border: 2px dashed var(--accent);
+  border-radius: var(--radius-md);
+  background-color: var(--bg-secondary);
 }
 
 .blockBar {

--- a/src/components/ProjectBlocks/editor/ProjectPageEditor.tsx
+++ b/src/components/ProjectBlocks/editor/ProjectPageEditor.tsx
@@ -265,14 +265,26 @@ export default function ProjectPageEditor({
         {blocks.map((block, index) => {
           const editing = editingId === block.id;
           const shown = editing && draft ? draft : block;
-          const floating = drag.draggingKey === block.id;
+
+          // The dragged block is lifted into a floating clone (rendered below);
+          // here it leaves a dashed placeholder so the drop target is visible and
+          // the list reflows live as the order changes.
+          if (drag.draggingKey === block.id) {
+            return (
+              <li
+                key={block.id}
+                className={styles.placeholder}
+                style={{ height: drag.size.h }}
+                aria-hidden="true"
+              />
+            );
+          }
 
           return (
             <li
               key={block.id}
               ref={drag.registerCard(block.id)}
-              className={`${styles.blockItem} ${floating ? styles.floating : ""}`}
-              style={floating ? drag.floatingStyle : undefined}
+              className={styles.blockItem}
             >
               <div className={styles.blockBar}>
                 <button
@@ -339,6 +351,23 @@ export default function ProjectPageEditor({
           );
         })}
       </ul>
+
+      {drag.draggingKey && (() => {
+        const dragged = blocks.find((b) => b.id === drag.draggingKey);
+        if (!dragged) return null;
+        return (
+          <div className={styles.floatingLayer} style={drag.floatingStyle}>
+            <div className={`${styles.blockItem} ${styles.floating}`}>
+              <div className={styles.blockBar}>
+                <span className={styles.dragHandle} aria-hidden="true">
+                  <FontAwesomeIcon icon={faGripVertical} />
+                </span>
+                <span className={styles.blockTag}>{BLOCK_LABELS[dragged.type]}</span>
+              </div>
+            </div>
+          </div>
+        );
+      })()}
 
       <div className={styles.addZone}>
         {paletteOpen ? (


### PR DESCRIPTION
This pull request improves the drag-and-drop experience in the `ProjectPageEditor` component by visually distinguishing the dragged block and its drop target. Now, when a block is being dragged, a floating clone follows the cursor while a dashed placeholder marks the potential drop position in the list, making the reordering process clearer and more intuitive.

**Drag-and-drop UI enhancements:**

* Added a dashed `.placeholder` element to the list, which appears at the live drop target position when a block is being dragged, allowing the list to reflow and clearly marking where the dragged block will be inserted. [[1]](diffhunk://#diff-0ceb67dd79d04ad91d6dfbbc1e2d34517ce506295ce0422f09bc07810fa01cf9L268-R287) [[2]](diffhunk://#diff-f8a53d2451880d5a2b892373c86f0e9b39d9abefba7d286f1b377c92b924dd68L54-R70)
* Introduced a `.floatingLayer` that renders a floating clone of the dragged block, following the cursor for better visual feedback. [[1]](diffhunk://#diff-0ceb67dd79d04ad91d6dfbbc1e2d34517ce506295ce0422f09bc07810fa01cf9R355-R371) [[2]](diffhunk://#diff-f8a53d2451880d5a2b892373c86f0e9b39d9abefba7d286f1b377c92b924dd68L54-R70)
* Updated styles in `ProjectPageEditor.module.scss` to support the new `.floatingLayer`, `.floating`, and `.placeholder` elements, ensuring proper appearance for both the floating block and the placeholder.